### PR TITLE
fix(sftp): serialize transfers and dismiss delete confirm (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ### Fixed
 
 - **SFTP multi-file transfer** — Sequential queue so a second Enter no longer overlaps the first transfer. Progress shows one file at a time (`[1/2]`, `[2/2]`) instead of flickering names. The SFTP subsystem is reused and serialized; transfer or refresh errors stay in the browser instead of dumping the session.
+- **SFTP delete confirm** — The `[Y/n]` prompt closes as soon as you confirm, so it no longer sits under the “Deleted successfully” toast.
 
 ## [0.5.2] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.5.3] - 2026-09-02
+
+### Fixed
+
+- **SFTP multi-file transfer** — Sequential queue so a second Enter no longer overlaps the first transfer. Progress shows one file at a time (`[1/2]`, `[2/2]`) instead of flickering names. The SFTP subsystem is reused and serialized; transfer or refresh errors stay in the browser instead of dumping the session.
+
 ## [0.5.2] - 2026-09-02
 
 ### Added

--- a/internal/sftpconfig/sftp.go
+++ b/internal/sftpconfig/sftp.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/zsuroy/ctty/internal/config"
@@ -19,9 +20,13 @@ import (
 	"golang.org/x/crypto/ssh/knownhosts"
 )
 
-// SFTPClient wraps an SSH connection + SFTP session.
+// SFTPClient wraps an SSH connection + one reused SFTP session.
+// All remote ops share that session and are serialized with mu so a
+// directory refresh cannot overlap an in-flight upload/download.
 type SFTPClient struct {
 	sshClient  *ssh.Client
+	sftp       *sftpWrapper
+	mu         sync.Mutex
 	host       config.SSHHost
 	configFile string
 }
@@ -280,12 +285,22 @@ func expandPath(path string) string {
 	return path
 }
 
-// Close closes the underlying SSH connection.
+// Close closes the SFTP session and the underlying SSH connection.
 func (c *SFTPClient) Close() error {
-	if c.sshClient != nil {
-		return c.sshClient.Close()
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var err error
+	if c.sftp != nil {
+		err = c.sftp.Close()
+		c.sftp = nil
 	}
-	return nil
+	if c.sshClient != nil {
+		if e := c.sshClient.Close(); e != nil && err == nil {
+			err = e
+		}
+		c.sshClient = nil
+	}
+	return err
 }
 
 // HostName returns the name of the connected host.
@@ -299,236 +314,190 @@ func (c *SFTPClient) HostName() string {
 // and returns its output. Used as a lightweight alternative to the SFTP subsystem.
 // Actually, we'll use the SFTP subsystem directly via github.com/pkg/sftp.
 
-// startSFTP opens an SFTP session over the SSH connection.
-func (c *SFTPClient) newSFTPSession() (*sftpWrapper, error) {
+func (c *SFTPClient) getSession() (*sftpWrapper, error) {
+	if c.sftp != nil {
+		return c.sftp, nil
+	}
 	sc, err := sftpNewClient(c.sshClient)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start SFTP subsystem: %w", err)
 	}
+	c.sftp = sc
 	return sc, nil
+}
+
+func (c *SFTPClient) withSession(fn func(*sftpWrapper) error) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	sc, err := c.getSession()
+	if err != nil {
+		return err
+	}
+	return fn(sc)
 }
 
 // ListDir lists the contents of a remote directory.
 func (c *SFTPClient) ListDir(path string) ([]RemoteEntry, error) {
-	sc, err := c.newSFTPSession()
-	if err != nil {
-		return nil, err
-	}
-	defer sc.Close()
-
-	entries, err := sc.ReadDir(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read directory %s: %w", path, err)
-	}
-
 	var result []RemoteEntry
-	for _, entry := range entries {
-		info, err := entry.Info()
+	err := c.withSession(func(sc *sftpWrapper) error {
+		entries, err := sc.ReadDir(path)
 		if err != nil {
-			continue
+			return fmt.Errorf("failed to read directory %s: %w", path, err)
 		}
-		result = append(result, RemoteEntry{
-			Name:     entry.Name(),
-			IsDir:    entry.IsDir(),
-			Size:     info.Size(),
-			ModTime:  info.ModTime(),
-			Mode:     info.Mode().String(),
-			LongName: formatLongEntry(entry),
-		})
-	}
-
-	return result, nil
+		for _, entry := range entries {
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			result = append(result, RemoteEntry{
+				Name:     entry.Name(),
+				IsDir:    entry.IsDir(),
+				Size:     info.Size(),
+				ModTime:  info.ModTime(),
+				Mode:     info.Mode().String(),
+				LongName: formatLongEntry(entry),
+			})
+		}
+		return nil
+	})
+	return result, err
 }
 
 // Download downloads a remote file to a local path.
 func (c *SFTPClient) Download(remotePath, localPath string) error {
-	sc, err := c.newSFTPSession()
-	if err != nil {
-		return err
-	}
-	defer sc.Close()
-
-	remoteFile, err := sc.Open(remotePath)
-	if err != nil {
-		return fmt.Errorf("failed to open remote file %s: %w", remotePath, err)
-	}
-	defer remoteFile.Close()
-
-	localFile, err := os.Create(localPath)
-	if err != nil {
-		return fmt.Errorf("failed to create local file %s: %w", localPath, err)
-	}
-	defer localFile.Close()
-
-	_, err = io.Copy(localFile, remoteFile)
-	return err
+	return c.DownloadWithProgress(remotePath, localPath, nil)
 }
 
 // DownloadWithProgress downloads a remote file with a progress callback.
 // The callback receives bytes downloaded and total size.
 func (c *SFTPClient) DownloadWithProgress(remotePath, localPath string, progress func(downloaded, total int64)) error {
-	sc, err := c.newSFTPSession()
-	if err != nil {
-		return err
-	}
-	defer sc.Close()
-
-	remoteFile, err := sc.Open(remotePath)
-	if err != nil {
-		return fmt.Errorf("failed to open remote file %s: %w", remotePath, err)
-	}
-	defer remoteFile.Close()
-
-	stat, err := remoteFile.Stat()
-	if err != nil {
-		return fmt.Errorf("failed to stat remote file: %w", err)
-	}
-	totalSize := stat.Size()
-
-	localFile, err := os.Create(localPath)
-	if err != nil {
-		return fmt.Errorf("failed to create local file %s: %w", localPath, err)
-	}
-	defer localFile.Close()
-
-	buf := make([]byte, 32*1024)
-	var downloaded int64
-	for {
-		n, err := remoteFile.Read(buf)
-		if n > 0 {
-			if _, werr := localFile.Write(buf[:n]); werr != nil {
-				return werr
-			}
-			downloaded += int64(n)
-			if progress != nil {
-				progress(downloaded, totalSize)
-			}
-		}
-		if err == io.EOF {
-			break
-		}
+	return c.withSession(func(sc *sftpWrapper) error {
+		remoteFile, err := sc.Open(remotePath)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to open remote file %s: %w", remotePath, err)
 		}
-	}
-	return nil
+		defer remoteFile.Close()
+
+		stat, err := remoteFile.Stat()
+		if err != nil {
+			return fmt.Errorf("failed to stat remote file: %w", err)
+		}
+		totalSize := stat.Size()
+
+		localFile, err := os.Create(localPath)
+		if err != nil {
+			return fmt.Errorf("failed to create local file %s: %w", localPath, err)
+		}
+		defer localFile.Close()
+
+		buf := make([]byte, 32*1024)
+		var downloaded int64
+		for {
+			n, err := remoteFile.Read(buf)
+			if n > 0 {
+				if _, werr := localFile.Write(buf[:n]); werr != nil {
+					return werr
+				}
+				downloaded += int64(n)
+				if progress != nil {
+					progress(downloaded, totalSize)
+				}
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // UploadWithProgress uploads a local file with a progress callback.
 func (c *SFTPClient) UploadWithProgress(localPath, remotePath string, progress func(uploaded, total int64)) error {
-	sc, err := c.newSFTPSession()
-	if err != nil {
-		return err
-	}
-	defer sc.Close()
-
-	localFile, err := os.Open(localPath)
-	if err != nil {
-		return fmt.Errorf("failed to open local file %s: %w", localPath, err)
-	}
-	defer localFile.Close()
-
-	stat, err := localFile.Stat()
-	if err != nil {
-		return fmt.Errorf("failed to stat local file: %w", err)
-	}
-	totalSize := stat.Size()
-
-	remoteFile, err := sc.Create(remotePath)
-	if err != nil {
-		return fmt.Errorf("failed to create remote file %s: %w", remotePath, err)
-	}
-	defer remoteFile.Close()
-
-	buf := make([]byte, 32*1024)
-	var uploaded int64
-	for {
-		n, err := localFile.Read(buf)
-		if n > 0 {
-			if _, werr := remoteFile.Write(buf[:n]); werr != nil {
-				return werr
-			}
-			uploaded += int64(n)
-			if progress != nil {
-				progress(uploaded, totalSize)
-			}
-		}
-		if err == io.EOF {
-			break
-		}
+	return c.withSession(func(sc *sftpWrapper) error {
+		localFile, err := os.Open(localPath)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to open local file %s: %w", localPath, err)
 		}
-	}
-	return nil
+		defer localFile.Close()
+
+		stat, err := localFile.Stat()
+		if err != nil {
+			return fmt.Errorf("failed to stat local file: %w", err)
+		}
+		totalSize := stat.Size()
+
+		remoteFile, err := sc.Create(remotePath)
+		if err != nil {
+			return fmt.Errorf("failed to create remote file %s: %w", remotePath, err)
+		}
+		defer remoteFile.Close()
+
+		buf := make([]byte, 32*1024)
+		var uploaded int64
+		for {
+			n, err := localFile.Read(buf)
+			if n > 0 {
+				if _, werr := remoteFile.Write(buf[:n]); werr != nil {
+					return werr
+				}
+				uploaded += int64(n)
+				if progress != nil {
+					progress(uploaded, totalSize)
+				}
+			}
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
 }
 
 // Upload uploads a local file to a remote path.
 func (c *SFTPClient) Upload(localPath, remotePath string) error {
-	sc, err := c.newSFTPSession()
-	if err != nil {
-		return err
-	}
-	defer sc.Close()
-
-	localFile, err := os.Open(localPath)
-	if err != nil {
-		return fmt.Errorf("failed to open local file %s: %w", localPath, err)
-	}
-	defer localFile.Close()
-
-	remoteFile, err := sc.Create(remotePath)
-	if err != nil {
-		return fmt.Errorf("failed to create remote file %s: %w", remotePath, err)
-	}
-	defer remoteFile.Close()
-
-	_, err = io.Copy(remoteFile, localFile)
-	return err
+	return c.UploadWithProgress(localPath, remotePath, nil)
 }
 
 // Stat returns info about a remote path.
 func (c *SFTPClient) Stat(path string) (os.FileInfo, error) {
-	sc, err := c.newSFTPSession()
-	if err != nil {
-		return nil, err
-	}
-	defer sc.Close()
-
-	return sc.Stat(path)
+	var info os.FileInfo
+	err := c.withSession(func(sc *sftpWrapper) error {
+		var err error
+		info, err = sc.Stat(path)
+		return err
+	})
+	return info, err
 }
 
 // Mkdir creates a directory on the remote host.
 func (c *SFTPClient) Mkdir(path string) error {
-	sc, err := c.newSFTPSession()
-	if err != nil {
-		return err
-	}
-	defer sc.Close()
-
-	return sc.Mkdir(path)
+	return c.withSession(func(sc *sftpWrapper) error {
+		return sc.Mkdir(path)
+	})
 }
 
 // Remove deletes a file on the remote host.
 func (c *SFTPClient) Remove(path string) error {
-	sc, err := c.newSFTPSession()
-	if err != nil {
-		return err
-	}
-	defer sc.Close()
-
-	return sc.Remove(path)
+	return c.withSession(func(sc *sftpWrapper) error {
+		return sc.Remove(path)
+	})
 }
 
 // RealPath returns the canonical absolute path.
 func (c *SFTPClient) RealPath(path string) (string, error) {
-	sc, err := c.newSFTPSession()
-	if err != nil {
-		return "", err
-	}
-	defer sc.Close()
-
-	return sc.RealPath(path)
+	var resolved string
+	err := c.withSession(func(sc *sftpWrapper) error {
+		var err error
+		resolved, err = sc.RealPath(path)
+		return err
+	})
+	return resolved, err
 }
 
 // formatLongEntry formats a remote entry similar to `ls -l` output.

--- a/internal/ui/sftp_delete_test.go
+++ b/internal/ui/sftp_delete_test.go
@@ -1,0 +1,51 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/zsuroy/ctty/internal/i18n"
+	"github.com/zsuroy/ctty/internal/sftpconfig"
+)
+
+func TestSFTPDeleteConfirmLeavesOnYes(t *testing.T) {
+	i18n.SetLang("en")
+	m := NewSFTPForm(NewStyles(80), 80, 24, "host", "")
+	m.client = &sftpconfig.SFTPClient{}
+	m.ready = true
+	m.cwd = "/tmp"
+	m.mode = sftpDeleteConfirm
+	m.selectedEntry = &sftpconfig.RemoteEntry{Name: "dockerview"}
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("y")})
+	sm := updated.(*sftpFormModel)
+	if sm.mode == sftpDeleteConfirm {
+		t.Fatal("confirm dialog must close as soon as Y is pressed")
+	}
+	if strings.Contains(sm.View(), "Delete 'dockerview'") {
+		t.Fatalf("confirm still visible:\n%s", sm.View())
+	}
+}
+
+func TestSFTPDeleteSuccessHidesConfirmPrompt(t *testing.T) {
+	i18n.SetLang("en")
+	m := NewSFTPForm(NewStyles(80), 80, 24, "host", "")
+	m.client = &sftpconfig.SFTPClient{}
+	m.ready = true
+	m.cwd = "/tmp"
+	m.mode = sftpDeleteConfirm
+	m.selectedEntry = &sftpconfig.RemoteEntry{Name: "dockerview"}
+
+	_, _ = m.Update(sftpDeleteResultMsg{filename: "dockerview", success: true})
+	if m.mode != sftpBrowse {
+		t.Fatalf("mode=%v, want browse after delete", m.mode)
+	}
+	view := m.View()
+	if strings.Contains(view, "Delete 'dockerview'") {
+		t.Fatalf("confirm stacked on success:\n%s", view)
+	}
+	if !strings.Contains(view, "dockerview") || !strings.Contains(strings.ToLower(view), "deleted") {
+		t.Fatalf("missing delete success status:\n%s", view)
+	}
+}

--- a/internal/ui/sftp_transfer.go
+++ b/internal/ui/sftp_transfer.go
@@ -1,0 +1,86 @@
+package ui
+
+import "fmt"
+
+type sftpTransferJob struct {
+	filename   string
+	localPath  string
+	remotePath string
+	isUpload   bool
+}
+
+type sftpTransferQueue struct {
+	jobs []sftpTransferJob
+	idx  int
+}
+
+func (q *sftpTransferQueue) empty() bool {
+	return len(q.jobs) == 0
+}
+
+func (q *sftpTransferQueue) current() sftpTransferJob {
+	if q.empty() || q.idx < 0 || q.idx >= len(q.jobs) {
+		return sftpTransferJob{}
+	}
+	return q.jobs[q.idx]
+}
+
+func (q *sftpTransferQueue) position() (cur, total int) {
+	if q.empty() {
+		return 0, 0
+	}
+	return q.idx + 1, len(q.jobs)
+}
+
+// startOrEnqueue starts job immediately when idle, otherwise queues it
+// behind the in-flight transfer. started is true only when this job
+// should begin now.
+func (q *sftpTransferQueue) startOrEnqueue(job sftpTransferJob) (sftpTransferJob, bool) {
+	if q.empty() {
+		q.jobs = []sftpTransferJob{job}
+		q.idx = 0
+		return job, true
+	}
+	q.jobs = append(q.jobs, job)
+	return sftpTransferJob{}, false
+}
+
+func (q *sftpTransferQueue) finishCurrent() (sftpTransferJob, bool) {
+	if q.empty() {
+		return sftpTransferJob{}, false
+	}
+	if q.idx+1 < len(q.jobs) {
+		q.idx++
+		return q.jobs[q.idx], true
+	}
+	q.clear()
+	return sftpTransferJob{}, false
+}
+
+func (q *sftpTransferQueue) clear() {
+	q.jobs = nil
+	q.idx = 0
+}
+
+func staleSFTPProgress(transferring bool, currentGen, msgGen int) bool {
+	return !transferring || currentGen != msgGen
+}
+
+func formatSFTPProgress(job sftpTransferJob, done, total int64, cur, count int) string {
+	action := "Downloading"
+	if job.isUpload {
+		action = "Uploading"
+	}
+	var body string
+	if total > 0 {
+		pct := done * 100 / total
+		body = fmt.Sprintf("%s %s: %s / %s (%d%%)",
+			action, job.filename, formatSize(done), formatSize(total), pct)
+	} else {
+		body = fmt.Sprintf("%s %s: %s", action, job.filename, formatSize(done))
+	}
+	if count > 1 {
+		body = fmt.Sprintf("%s  [%d/%d]", body, cur, count)
+	}
+	return body
+}

--- a/internal/ui/sftp_transfer_test.go
+++ b/internal/ui/sftp_transfer_test.go
@@ -1,0 +1,161 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/zsuroy/ctty/internal/sftpconfig"
+)
+
+func TestSFTPTransferQueueRunsOneFileAtATime(t *testing.T) {
+	var q sftpTransferQueue
+	first, started := q.startOrEnqueue(sftpTransferJob{filename: "a.bin", isUpload: true})
+	if !started || first.filename != "a.bin" {
+		t.Fatalf("first start: started=%v job=%+v", started, first)
+	}
+	cur, total := q.position()
+	if cur != 1 || total != 1 {
+		t.Fatalf("position after first = %d/%d", cur, total)
+	}
+
+	_, started = q.startOrEnqueue(sftpTransferJob{filename: "b.bin", isUpload: true})
+	if started {
+		t.Fatal("second file must be queued, not started concurrently")
+	}
+	cur, total = q.position()
+	if cur != 1 || total != 2 {
+		t.Fatalf("position while first runs = %d/%d, want 1/2", cur, total)
+	}
+	if q.current().filename != "a.bin" {
+		t.Fatalf("current = %q, want a.bin", q.current().filename)
+	}
+
+	next, ok := q.finishCurrent()
+	if !ok || next.filename != "b.bin" {
+		t.Fatalf("advance: ok=%v next=%+v", ok, next)
+	}
+	cur, total = q.position()
+	if cur != 2 || total != 2 {
+		t.Fatalf("position for second = %d/%d, want 2/2", cur, total)
+	}
+
+	_, ok = q.finishCurrent()
+	if ok {
+		t.Fatal("queue should be empty after the last file")
+	}
+	if !q.empty() {
+		t.Fatal("expected empty queue")
+	}
+}
+
+func TestFormatSFTPProgressShowsOnlyCurrentFile(t *testing.T) {
+	job := sftpTransferJob{filename: "b.bin", isUpload: true}
+	got := formatSFTPProgress(job, 50, 100, 2, 2)
+	if strings.Contains(got, "a.bin") {
+		t.Fatalf("progress leaked another filename: %q", got)
+	}
+	if !strings.Contains(got, "b.bin") {
+		t.Fatalf("missing current file: %q", got)
+	}
+	if !strings.Contains(got, "2/2") {
+		t.Fatalf("missing queue position: %q", got)
+	}
+	if !strings.Contains(got, "50%") {
+		t.Fatalf("missing percent: %q", got)
+	}
+}
+
+func TestStaleSFTPProgressIsIgnored(t *testing.T) {
+	if !staleSFTPProgress(true, 2, 1) {
+		t.Fatal("older generation should be stale")
+	}
+	if staleSFTPProgress(true, 2, 2) {
+		t.Fatal("current generation should be live")
+	}
+	if !staleSFTPProgress(false, 2, 2) {
+		t.Fatal("progress while idle should be stale")
+	}
+}
+
+func TestSFTPIgnoresStaleProgressTick(t *testing.T) {
+	m := NewSFTPForm(NewStyles(80), 80, 24, "host", "")
+	m.client = &sftpconfig.SFTPClient{}
+	m.loading = true
+	m.transferring = true
+	m.progressGen = 2
+	m.statusMsg = "Uploading b.bin: 0B / 100B (0%)"
+
+	_, cmd := m.Update(sftpProgressMsg{
+		gen: 1, filename: "a.bin", downloaded: 50, total: 100, isUpload: true,
+	})
+	if strings.Contains(m.statusMsg, "a.bin") {
+		t.Fatalf("stale tick updated status: %q", m.statusMsg)
+	}
+	if cmd != nil {
+		t.Fatal("stale tick must not reschedule progress")
+	}
+}
+
+func TestSFTPTransferErrorStaysInSession(t *testing.T) {
+	m := NewSFTPForm(NewStyles(80), 80, 24, "host", "")
+	m.client = &sftpconfig.SFTPClient{}
+	m.ready = true
+	m.mode = sftpBrowse
+	m.loading = true
+	m.transferring = true
+	m.progressGen = 1
+	m.queue.startOrEnqueue(sftpTransferJob{filename: "b.bin", isUpload: true})
+
+	_, cmd := m.Update(sftpUploadResultMsg{gen: 1, filename: "b.bin", success: false, err: errSFTPTest{}})
+	if m.mode == sftpError {
+		t.Fatal("transfer failure must not dump the whole SFTP session")
+	}
+	if m.transferring {
+		t.Fatal("transferring should clear after the last file fails")
+	}
+	if cmd == nil {
+		t.Fatal("expected a directory refresh after the queue drains")
+	}
+}
+
+func TestSFTPIgnoresStaleTransferResult(t *testing.T) {
+	m := NewSFTPForm(NewStyles(80), 80, 24, "host", "")
+	m.client = &sftpconfig.SFTPClient{}
+	m.ready = true
+	m.mode = sftpBrowse
+	m.loading = true
+	m.transferring = true
+	m.progressGen = 2
+	m.queue.startOrEnqueue(sftpTransferJob{filename: "b.bin", isUpload: true})
+
+	_, cmd := m.Update(sftpUploadResultMsg{gen: 1, filename: "a.bin", success: true})
+	if !m.transferring {
+		t.Fatal("current transfer must not finish on a stale result")
+	}
+	if cmd != nil {
+		t.Fatal("stale result must not refresh the directory")
+	}
+	if m.queue.current().filename != "b.bin" {
+		t.Fatalf("queue current = %q", m.queue.current().filename)
+	}
+}
+
+func TestSFTPListErrorKeepsCurrentDirectory(t *testing.T) {
+	m := NewSFTPForm(NewStyles(80), 80, 24, "host", "")
+	m.client = &sftpconfig.SFTPClient{}
+	m.ready = true
+	m.mode = sftpBrowse
+	m.entries = []sftpconfig.RemoteEntry{{Name: "keep-me"}}
+
+	_, _ = m.Update(sftpEntriesMsg{cwd: "/tmp", err: errSFTPTest{}})
+	if m.mode == sftpError {
+		t.Fatal("list failure after connect must not exit SFTP")
+	}
+	if len(m.entries) != 1 || m.entries[0].Name != "keep-me" {
+		t.Fatalf("entries = %+v, want keep-me", m.entries)
+	}
+}
+
+type errSFTPTest struct{}
+
+func (errSFTPTest) Error() string { return "sftp boom" }

--- a/internal/ui/sftp_view.go
+++ b/internal/ui/sftp_view.go
@@ -53,6 +53,9 @@ type sftpFormModel struct {
 	progressDone  int64
 	progressTotal int64
 	progressFile  string
+	progressGen   int
+	transferring  bool
+	queue         sftpTransferQueue
 
 	// For input modes
 	inputBuffer string
@@ -84,6 +87,7 @@ type sftpConnectedMsg struct {
 type sftpEntriesMsg struct {
 	entries []sftpconfig.RemoteEntry
 	cwd     string
+	err     error
 }
 
 type sftpErrorMsg struct {
@@ -91,12 +95,14 @@ type sftpErrorMsg struct {
 }
 
 type sftpDownloadResultMsg struct {
+	gen      int
 	filename string
 	success  bool
 	err      error
 }
 
 type sftpProgressMsg struct {
+	gen        int
 	filename   string
 	downloaded int64
 	total      int64
@@ -104,6 +110,7 @@ type sftpProgressMsg struct {
 }
 
 type sftpUploadResultMsg struct {
+	gen      int
 	filename string
 	success  bool
 	err      error
@@ -186,14 +193,61 @@ func (m *sftpFormModel) loadDirCmd(path string) tea.Cmd {
 	return func() tea.Msg {
 		entries, err := m.client.ListDir(path)
 		if err != nil {
-			return sftpErrorMsg{err: err}
+			return sftpEntriesMsg{cwd: path, err: err}
 		}
 		return sftpEntriesMsg{entries: entries, cwd: path}
 	}
 }
 
+func (m *sftpFormModel) requestTransfer(job sftpTransferJob) tea.Cmd {
+	started, now := m.queue.startOrEnqueue(job)
+	if !now {
+		return nil
+	}
+	return m.beginJob(started)
+}
+
+func (m *sftpFormModel) beginJob(job sftpTransferJob) tea.Cmd {
+	m.transferring = true
+	m.loading = true
+	m.progressFile = job.filename
+	m.progressDone = 0
+	m.progressTotal = 0
+	cur, total := m.queue.position()
+	m.statusMsg = formatSFTPProgress(job, 0, 0, cur, total)
+	m.statusExpiry = time.Now().Add(10 * time.Second)
+	if job.isUpload {
+		return m.uploadCmd(job.localPath, job.remotePath)
+	}
+	return m.downloadCmd(job.remotePath, job.localPath)
+}
+
+func (m *sftpFormModel) handleTransferResult(gen int, filename string, success bool, err error, isUpload bool) tea.Cmd {
+	if !m.transferring || gen != m.progressGen {
+		return nil
+	}
+	next, ok := m.queue.finishCurrent()
+	if ok {
+		return m.beginJob(next)
+	}
+	m.transferring = false
+	m.loading = false
+	if success {
+		if isUpload {
+			m.setStatus("Uploaded: " + filename)
+		} else {
+			m.setStatus(fmt.Sprintf("Downloaded: %s → %s", filename, m.localDownloadPath(filename)))
+		}
+	} else if err != nil {
+		m.setStatus("Failed: " + filename + ": " + err.Error())
+	}
+	return m.loadDirCmd(m.cwd)
+}
+
 func (m *sftpFormModel) downloadCmd(remotePath, localPath string) tea.Cmd {
 	filename := filepath.Base(remotePath)
+	m.progressGen++
+	gen := m.progressGen
 	m.progressFile = filename
 	m.progressDone = 0
 	m.progressTotal = 0
@@ -203,19 +257,21 @@ func (m *sftpFormModel) downloadCmd(remotePath, localPath string) tea.Cmd {
 			m.progressDone = downloaded
 			m.progressTotal = total
 		})
-		return sftpDownloadResultMsg{filename: filename, success: err == nil, err: err}
+		return sftpDownloadResultMsg{gen: gen, filename: filename, success: err == nil, err: err}
 	}
 
 	return tea.Batch(
 		download,
 		tea.Tick(200*time.Millisecond, func(t time.Time) tea.Msg {
-			return sftpProgressMsg{filename: filename, downloaded: m.progressDone, total: m.progressTotal, isUpload: false}
+			return sftpProgressMsg{gen: gen, filename: filename, downloaded: m.progressDone, total: m.progressTotal, isUpload: false}
 		}),
 	)
 }
 
 func (m *sftpFormModel) uploadCmd(localPath, remotePath string) tea.Cmd {
 	filename := filepath.Base(localPath)
+	m.progressGen++
+	gen := m.progressGen
 	m.progressFile = filename
 	m.progressDone = 0
 	m.progressTotal = 0
@@ -225,13 +281,13 @@ func (m *sftpFormModel) uploadCmd(localPath, remotePath string) tea.Cmd {
 			m.progressDone = uploaded
 			m.progressTotal = total
 		})
-		return sftpUploadResultMsg{filename: filename, success: err == nil, err: err}
+		return sftpUploadResultMsg{gen: gen, filename: filename, success: err == nil, err: err}
 	}
 
 	return tea.Batch(
 		upload,
 		tea.Tick(200*time.Millisecond, func(t time.Time) tea.Msg {
-			return sftpProgressMsg{filename: filename, downloaded: m.progressDone, total: m.progressTotal, isUpload: true}
+			return sftpProgressMsg{gen: gen, filename: filename, downloaded: m.progressDone, total: m.progressTotal, isUpload: true}
 		}),
 	)
 }
@@ -284,9 +340,20 @@ func (m *sftpFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case sftpEntriesMsg:
 		m.loading = false
+		if msg.err != nil {
+			if !m.ready {
+				m.loadError = msg.err.Error()
+				m.mode = sftpError
+				return m, nil
+			}
+			m.setStatus("Refresh failed: " + msg.err.Error())
+			return m, nil
+		}
 		m.entries = msg.entries
 		m.cwd = msg.cwd
-		m.updateTableRows()
+		if m.mode != sftpUploadSelect {
+			m.updateTableRows()
+		}
 		return m, nil
 
 	case sftpErrorMsg:
@@ -296,47 +363,25 @@ func (m *sftpFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case sftpProgressMsg:
-		// Ignore progress if download was cancelled
-		if !m.loading {
+		if staleSFTPProgress(m.transferring, m.progressGen, msg.gen) {
 			return m, nil
 		}
-		// Update progress display
-		action := "Downloading"
-		if msg.isUpload {
-			action = "Uploading"
+		job := m.queue.current()
+		if job.filename == "" {
+			job = sftpTransferJob{filename: msg.filename, isUpload: msg.isUpload}
 		}
-		if msg.total > 0 {
-			pct := msg.downloaded * 100 / msg.total
-			m.statusMsg = fmt.Sprintf("%s %s: %s / %s (%d%%)",
-				action, msg.filename, formatSize(msg.downloaded), formatSize(msg.total), pct)
-		} else {
-			m.statusMsg = fmt.Sprintf("%s %s: %s", action, msg.filename, formatSize(msg.downloaded))
-		}
+		cur, count := m.queue.position()
+		m.statusMsg = formatSFTPProgress(job, msg.downloaded, msg.total, cur, count)
 		m.statusExpiry = time.Now().Add(10 * time.Second)
-		// Keep ticking if still loading
 		return m, tea.Tick(200*time.Millisecond, func(t time.Time) tea.Msg {
-			return sftpProgressMsg{filename: msg.filename, downloaded: m.progressDone, total: m.progressTotal, isUpload: msg.isUpload}
+			return sftpProgressMsg{gen: msg.gen, filename: job.filename, downloaded: m.progressDone, total: m.progressTotal, isUpload: job.isUpload}
 		})
 
 	case sftpDownloadResultMsg:
-		m.loading = false
-		if msg.success {
-			m.setStatus(fmt.Sprintf("Downloaded: %s → %s", msg.filename, m.localDownloadPath(msg.filename)))
-		} else {
-			m.loadError = msg.err.Error()
-			m.mode = sftpError
-		}
-		return m, nil
+		return m, m.handleTransferResult(msg.gen, msg.filename, msg.success, msg.err, false)
 
 	case sftpUploadResultMsg:
-		m.loading = false
-		if msg.success {
-			m.setStatus("Uploaded: " + msg.filename)
-		} else {
-			m.loadError = msg.err.Error()
-			m.mode = sftpError
-		}
-		return m, m.loadDirCmd(m.cwd)
+		return m, m.handleTransferResult(msg.gen, msg.filename, msg.success, msg.err, true)
 	case sftpDeleteResultMsg:
 		if msg.success {
 			m.setStatus("Deleted successfully")
@@ -418,12 +463,16 @@ func (m *sftpFormModel) handleBrowseKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 	switch key {
 	case "esc", "q":
-		if m.loading && m.client != nil {
-			// Cancel ongoing download/upload
+		if m.transferring || (m.loading && m.client != nil) {
 			m.loading = false
+			m.transferring = false
+			m.progressGen++
+			m.queue.clear()
 			m.setStatus(fmt.Sprintf("Cancelled: %s", m.progressFile))
-			m.mode = sftpBrowse
-			m.updateTableRows()
+			if m.mode != sftpUploadSelect {
+				m.mode = sftpBrowse
+				m.updateTableRows()
+			}
 			return m, nil
 		}
 		return m, func() tea.Msg { return sftpDoneMsg{} }
@@ -444,12 +493,23 @@ func (m *sftpFormModel) handleBrowseKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		if entry == nil || entry.IsDir {
 			return m, nil
 		}
-		// File selected → show download confirm
+		job := sftpTransferJob{
+			filename:   entry.Name,
+			localPath:  m.localDownloadPath(entry.Name),
+			remotePath: path.Join(m.cwd, entry.Name),
+			isUpload:   false,
+		}
+		if m.transferring {
+			return m, m.requestTransfer(job)
+		}
 		m.selectedEntry = entry
 		m.mode = sftpDownloadConfirm
 		return m, nil
 
 	case "right", "l":
+		if m.transferring {
+			return m, nil
+		}
 		// Right/l: open directory
 		selected := m.table.SelectedRow()
 		if len(selected) == 0 {
@@ -466,6 +526,9 @@ func (m *sftpFormModel) handleBrowseKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.loadDirCmd(newPath)
 
 	case "left", "h", "backspace":
+		if m.transferring {
+			return m, nil
+		}
 		// Left/h/backspace: go to parent directory
 		parent := path.Dir(m.cwd)
 		if parent == m.cwd {
@@ -476,6 +539,9 @@ func (m *sftpFormModel) handleBrowseKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.loadDirCmd(parent)
 
 	case "u", "tab", "shift+tab":
+		if m.transferring {
+			return m, nil
+		}
 		// Upload: switch table to show local files
 		m.mode = sftpUploadSelect
 		if m.localCwd == "" {
@@ -487,6 +553,9 @@ func (m *sftpFormModel) handleBrowseKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "d":
+		if m.transferring {
+			return m, nil
+		}
 		// Delete selected file
 		selected := m.table.SelectedRow()
 		if len(selected) == 0 {
@@ -502,6 +571,9 @@ func (m *sftpFormModel) handleBrowseKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "n":
+		if m.transferring {
+			return m, nil
+		}
 		// New directory
 		m.mode = sftpMkdirInput
 		m.inputBuffer = ""
@@ -509,6 +581,9 @@ func (m *sftpFormModel) handleBrowseKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "r":
+		if m.transferring {
+			return m, nil
+		}
 		// Refresh
 		return m, m.loadDirCmd(m.cwd)
 
@@ -670,11 +745,15 @@ func (m *sftpFormModel) handleConfirmDialog(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		remotePath := path.Join(m.cwd, m.selectedEntry.Name)
 
 		if m.mode == sftpDownloadConfirm {
-			localPath := m.localDownloadPath(m.selectedEntry.Name)
-			m.loading = true
-			m.setStatus(fmt.Sprintf("Downloading %s", m.selectedEntry.Name))
 			m.mode = sftpBrowse
-			return m, m.downloadCmd(remotePath, localPath)
+			job := sftpTransferJob{
+				filename:   m.selectedEntry.Name,
+				localPath:  m.localDownloadPath(m.selectedEntry.Name),
+				remotePath: remotePath,
+				isUpload:   false,
+			}
+			m.selectedEntry = nil
+			return m, m.requestTransfer(job)
 		}
 
 		if m.mode == sftpDeleteConfirm {
@@ -690,11 +769,15 @@ func (m *sftpFormModel) handleConfirmDialog(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		}
 		remotePath := path.Join(m.cwd, m.selectedEntry.Name)
 		if m.mode == sftpDownloadConfirm {
-			localPath := m.localDownloadPath(m.selectedEntry.Name)
-			m.loading = true
-			m.setStatus(fmt.Sprintf("Downloading %s", m.selectedEntry.Name))
 			m.mode = sftpBrowse
-			return m, m.downloadCmd(remotePath, localPath)
+			job := sftpTransferJob{
+				filename:   m.selectedEntry.Name,
+				localPath:  m.localDownloadPath(m.selectedEntry.Name),
+				remotePath: remotePath,
+				isUpload:   false,
+			}
+			m.selectedEntry = nil
+			return m, m.requestTransfer(job)
 		}
 
 		if m.mode == sftpDeleteConfirm {
@@ -722,6 +805,14 @@ func (m *sftpFormModel) handleUploadSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 
 	switch key {
 	case "esc", "tab", "shift+tab":
+		if m.transferring {
+			m.loading = false
+			m.transferring = false
+			m.progressGen++
+			m.queue.clear()
+			m.setStatus(fmt.Sprintf("Cancelled: %s", m.progressFile))
+			return m, nil
+		}
 		m.mode = sftpBrowse
 		m.updateTableRows()
 		return m, nil
@@ -741,6 +832,9 @@ func (m *sftpFormModel) handleUploadSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 				return m, nil
 			}
 			if info.IsDir() {
+				if m.transferring {
+					return m, nil
+				}
 				m.localCwd = localPath
 				m.localFiles = m.listLocalFiles()
 				m.updateLocalTableRows()
@@ -748,17 +842,19 @@ func (m *sftpFormModel) handleUploadSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 				return m, nil
 			}
 			remotePath := path.Join(m.cwd, filepath.Base(localPath))
-			m.mode = sftpBrowse
-			m.loading = true
-			m.statusMsg = fmt.Sprintf("Uploading %s...", filepath.Base(localPath))
-			m.progressFile = filepath.Base(localPath)
-			m.progressDone = 0
-			m.progressTotal = 0
-			return m, m.uploadCmd(localPath, remotePath)
+			return m, m.requestTransfer(sftpTransferJob{
+				filename:   filepath.Base(localPath),
+				localPath:  localPath,
+				remotePath: remotePath,
+				isUpload:   true,
+			})
 		}
 		return m, nil
 
 	case "right", "l":
+		if m.transferring {
+			return m, nil
+		}
 		idx := m.table.Cursor()
 		if idx >= 0 && idx < len(m.localFiles) {
 			localPath := m.localFiles[idx]
@@ -773,6 +869,9 @@ func (m *sftpFormModel) handleUploadSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 		return m, nil
 
 	case "left", "h", "backspace":
+		if m.transferring {
+			return m, nil
+		}
 		parent := filepath.Dir(m.localCwd)
 		if parent != m.localCwd {
 			m.localCwd = parent

--- a/internal/ui/sftp_view.go
+++ b/internal/ui/sftp_view.go
@@ -117,8 +117,9 @@ type sftpUploadResultMsg struct {
 }
 
 type sftpDeleteResultMsg struct {
-	success bool
-	err     error
+	filename string
+	success  bool
+	err      error
 }
 
 type sftpMkdirResultMsg struct {
@@ -293,9 +294,10 @@ func (m *sftpFormModel) uploadCmd(localPath, remotePath string) tea.Cmd {
 }
 
 func (m *sftpFormModel) deleteCmd(remotePath string) tea.Cmd {
+	filename := path.Base(remotePath)
 	return func() tea.Msg {
 		err := m.client.Remove(remotePath)
-		return sftpDeleteResultMsg{success: err == nil, err: err}
+		return sftpDeleteResultMsg{filename: filename, success: err == nil, err: err}
 	}
 }
 
@@ -383,11 +385,17 @@ func (m *sftpFormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case sftpUploadResultMsg:
 		return m, m.handleTransferResult(msg.gen, msg.filename, msg.success, msg.err, true)
 	case sftpDeleteResultMsg:
+		m.loading = false
+		m.mode = sftpBrowse
+		m.selectedEntry = nil
 		if msg.success {
-			m.setStatus("Deleted successfully")
-		} else {
-			m.loadError = msg.err.Error()
-			m.mode = sftpError
+			name := msg.filename
+			if name == "" {
+				name = "file"
+			}
+			m.setStatus(i18n.T("sftp.delete_success", name))
+		} else if msg.err != nil {
+			m.setStatus(i18n.T("sftp.delete_failed", msg.err.Error()))
 		}
 		return m, m.loadDirCmd(m.cwd)
 
@@ -757,6 +765,12 @@ func (m *sftpFormModel) handleConfirmDialog(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		}
 
 		if m.mode == sftpDeleteConfirm {
+			name := m.selectedEntry.Name
+			m.mode = sftpBrowse
+			m.selectedEntry = nil
+			m.loading = true
+			m.statusMsg = i18n.T("sftp.deleting", name)
+			m.statusExpiry = time.Now().Add(10 * time.Second)
 			return m, m.deleteCmd(remotePath)
 		}
 
@@ -781,6 +795,12 @@ func (m *sftpFormModel) handleConfirmDialog(msg tea.KeyMsg) (tea.Model, tea.Cmd)
 		}
 
 		if m.mode == sftpDeleteConfirm {
+			name := m.selectedEntry.Name
+			m.mode = sftpBrowse
+			m.selectedEntry = nil
+			m.loading = true
+			m.statusMsg = i18n.T("sftp.deleting", name)
+			m.statusExpiry = time.Now().Add(10 * time.Second)
 			return m, m.deleteCmd(remotePath)
 		}
 

--- a/internal/ui/update.go
+++ b/internal/ui/update.go
@@ -452,6 +452,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case sftpDoneMsg:
+		if m.sftpForm != nil && m.sftpForm.client != nil {
+			_ = m.sftpForm.client.Close()
+		}
 		m.sftpForm = nil
 		m.viewMode = ViewList
 		m.table.Focus()


### PR DESCRIPTION
Closes #4

## Summary
- Queue SFTP uploads/downloads so a second Enter waits for the first file instead of opening another SFTP session
- Show one progress line at a time (`[1/2]`, `[2/2]`) instead of two filenames flickering
- Reuse a single SFTP subsystem for the whole browser session; list/refresh no longer races an in-flight transfer
- Transfer or refresh errors stay in the browser (no full-screen dump that required leaving the directory to recover)
- Close the delete `[Y/n]` prompt as soon as Y is pressed so it does not sit under “Deleted successfully”

## Test plan
- [x] On Linux ARM64 SFTP: `u`, directory with two files, Enter on the first then Enter on the second
- [x] Progress shows only the current file with `[1/2]` / `[2/2]`
- [x] Second file succeeds without changing directory to refresh
- [x] Transfer error stays in the browser as a status line
- [x] Delete with `d` then `Y`: confirm disappears immediately; success toast includes the filename
