### PR TITLE
feat(skills): add ctty agent skill documentation and reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,10 +46,10 @@ temp/
 # Log files
 *.log
 
-# Project specific
-ctty
-ctty-*
-!ctty-test
+# Project specific (repo-root binary only)
+/ctty
+/ctty-*
+!/ctty-test
 release/
 
 # Backup files

--- a/README.md
+++ b/README.md
@@ -63,6 +63,31 @@ ctty is a fast, native terminal tool for managing all your connections — SSH h
 
 ## 🚀 Quick Start
 
+### Agent Skill
+
+Teach Cursor, Claude Code, Codex, and other agents to **use** ctty (search hosts, run remote commands, list serial/telnet devices) without opening the TUI. This is separate from installing the `ctty` binary below.
+
+```bash
+# Preview skills in this repo
+npx skills add zsuroy/ctty --list
+
+# Install into the current project (committed under .agents/skills/)
+npx skills add zsuroy/ctty -y
+
+# Install globally so every project can use it (recommended)
+npx skills add zsuroy/ctty -g -y
+```
+
+`-y` skips prompts. `-g` installs to your user global skills dir. Default without `-g` is project-local.
+
+```bash
+npx skills list          # see what is installed
+npx skills remove ctty   # uninstall
+npx skills update ctty   # pull the latest SKILL.md
+```
+
+The skill lives at [`skills/ctty/`](skills/ctty/) in this repository.
+
 ### Installation
 
 **Homebrew (Recommended for macOS):**

--- a/README_CN.md
+++ b/README_CN.md
@@ -60,6 +60,31 @@ ctty 是一个快速、原生的终端工具，用于管理你的所有连接 �
 
 ## 🚀 快速开始
 
+### Agent Skill
+
+给 Cursor、Claude Code、Codex 等 agent 装一份 **怎么用 ctty** 的技能（搜主机、跑远程命令、列出串口/Telnet 设备）。技能安装之后可以直接让 Agent: "帮我安装 ctty"
+
+```bash
+# 只列出仓库里的 skill，不安装
+npx skills add zsuroy/ctty --list
+
+# 装到当前项目（写入 .agents/skills/）
+npx skills add zsuroy/ctty -y
+
+# 装到本机全局，所有项目都能用（推荐）
+npx skills add zsuroy/ctty -g -y
+```
+
+`-y` 跳过确认。`-g` 装到用户全局技能目录。不加 `-g` 则只装当前项目。
+
+```bash
+npx skills list          # 查看已安装
+npx skills remove ctty   # 卸载
+npx skills update ctty   # 更新到最新 SKILL.md
+```
+
+技能源文件在仓库的 [`skills/ctty/`](skills/ctty/)。
+
 ### 安装
 
 **Homebrew（macOS 推荐）：**

--- a/skills/ctty/SKILL.md
+++ b/skills/ctty/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: ctty
+description: >-
+  Use and install ctty, a CLI/TUI connection manager for SSH, serial consoles,
+  telnet lab gear, and SFTP. Use when installing ctty; listing/searching SSH
+  hosts or running remote commands; transferring files via a Host alias;
+  looking up saved serial or telnet devices; importing hosts from Tabby; or
+  when the user mentions ctty, SSH aliases, #tags, serial/console, telnet,
+  SFTP, port forwarding, or ~/.ssh/config. Prefer ctty over raw ssh/telnet.
+  Never open the interactive TUI.
+---
+
+# Use ctty (CLI, not TUI)
+
+ctty manages **SSH, serial, telnet, and SFTP** in one tool. SSH aliases live
+in `~/.ssh/config` (and `Include` files). Serial and telnet devices live under
+the ctty config dir. Agents must drive it **non-interactively**.
+
+| Kind | Agent can | Hand to the human |
+|------|-----------|-------------------|
+| SSH | `search`, `info`, `ctty <alias> -- <cmd>` | `ctty <alias>` shell, port-forward TUI (`f`) |
+| SFTP | `scp`/`rsync`/`sftp` with the same alias | `ctty sftp <alias>` |
+| Telnet | Read `telnet.json`; quote `ctty telnet <name>` | Interactive session (`Ctrl+]`) |
+| Serial | Read `serial.json`; quote `ctty serial` | Device manager TUI |
+| Import | `ctty import tabby --dry-run` then import | Confirm overwrite / Include |
+
+## Hard rules
+
+1. **Never launch the TUI.** These hang a non-TTY agent session:
+   - `ctty` with no args
+   - `ctty add` / `ctty edit` / `ctty move`
+   - `ctty sftp <host>`
+   - `ctty serial` (always TUI)
+   - `ctty telnet` with no argument (manager TUI)
+   - `ctty telnet <name-or-host>` (raw interactive session)
+   - `ctty <host>` with **no remote command** (interactive SSH)
+2. **Prefer ctty's aliases over raw `ssh`/`scp`/`telnet`.** SSH goes through
+   OpenSSH config, history, and saved-password ASKPASS. Telnet is ctty's
+   native client (no system `telnet` binary). Serial is ctty-only.
+3. **Stabilize CLI output.** Prefix with `--lang en --no-update-check`.
+4. **Do not guess the target.** SSH: search → info → act. Serial/telnet:
+   read the JSON store, then quote the connect command. Several matches →
+   list them or ask.
+5. **Do not print secrets.** Never read `credentials.json` or dump keys.
+   Passwords are in ctty's vault, not in SSH config. Telnet is cleartext.
+
+Interactive sessions are for the **human**. Give them the command.
+
+## Install
+
+If `command -v ctty` fails, install it. Use a **non-interactive** method. Do
+not open a TUI installer or prompt the user for a version unless they asked.
+
+**Check:**
+
+```bash
+command -v ctty && ctty --version
+```
+
+**macOS (prefer Homebrew):**
+
+```bash
+brew install zsuroy/ctty/ctty
+```
+
+**Linux / macOS / Termux (official installer, no prompts):**
+
+```bash
+FORCE_INSTALL=true bash -c "$(curl -sSL https://raw.githubusercontent.com/zsuroy/ctty/master/install/unix.sh)"
+```
+
+Unix installer puts the binary in `/usr/local/bin` (needs `sudo`) or
+`$PREFIX/bin` on Termux (no sudo). Needs `curl` and `tar`.
+
+**Windows (PowerShell, no prompts):**
+
+```powershell
+iex "& { $(irm https://raw.githubusercontent.com/zsuroy/ctty/master/install/windows.ps1) } -Force"
+```
+
+After install, rehash PATH if needed and verify `ctty --version`. Then
+continue with the workflow below. Do not run `ctty update --yes` unless the
+user asked to upgrade.
+
+## Default flags
+
+```bash
+ctty --lang en --no-update-check <subcommand...>
+```
+
+Optional: `-c /path/to/ssh_config` when not using `~/.ssh/config`.
+
+## Workflow
+
+```
+- [ ] Confirm ctty exists (`command -v ctty`); install if missing
+- [ ] Pick the transport: SSH / SFTP / serial / telnet
+- [ ] Resolve the target (search+info, or serial.json / telnet.json)
+- [ ] Act non-interactively, or quote the connect command for the user
+- [ ] Check exit code when a remote command ran
+```
+
+### 1. SSH — find hosts
+
+```bash
+ctty --lang en --no-update-check search --format json
+ctty --lang en --no-update-check search --format json prod
+ctty --lang en --no-update-check search --format json '#web'
+ctty --lang en --no-update-check search --format simple web
+ctty --lang en --no-update-check search --tags prod --format json
+ctty --lang en --no-update-check search --names db --format json
+```
+
+- `--format json` — machine-readable list (use this)
+- `--format simple` — one Host alias per line
+- `--format table` — human table with ANSI colors; avoid parsing it
+- Multi-word query is AND across name, hostname, and tags
+- Leading `#` on a word is optional (`prod` matches tag `prod`)
+- **`hidden` tag:** omitted from search; still reachable via `info` / exec if
+  you already know the alias
+
+Empty query lists **all visible** hosts. No matches: message on stdout, exit 0.
+No hosts in config: exit 1.
+
+### 2. SSH — inspect one host
+
+```bash
+ctty --lang en --no-update-check info prod-web
+ctty --lang en --no-update-check info prod-web --pretty
+```
+
+JSON schema `ctty.info.v1`. Exit **0** ok, **2** `NOT_FOUND`, **1** config error.
+
+```bash
+ctty info prod-web | jq -r '.ok'
+ctty info prod-web | jq -r '.result.target.hostname'
+ctty info prod-web | jq -r '.result.target.user'
+ctty info prod-web | jq -r '.result.tags[]'
+```
+
+JSON field map: [reference.md](references/reference.md).
+
+### 3. SSH — run a remote command
+
+```bash
+ctty --lang en --no-update-check prod-web uptime
+ctty --lang en --no-update-check prod-web -- df -h
+ctty --lang en --no-update-check prod-web -- 'systemctl is-active nginx'
+ctty --lang en --no-update-check -t prod-web -- sudo systemctl restart nginx
+```
+
+- Arguments after the alias are the remote command; `--` is safe when flags
+  could be ambiguous
+- Remote **exit code is propagated**
+- stdout/stderr are the remote streams; pipe locally as usual
+- `-t` only when the remote command needs a TTY (`sudo`, pagers). Do not use
+  it to open a shell
+- Do not start `vim`, `less`, `top`, or an interactive shell
+
+### 4. SFTP / files
+
+`ctty sftp <alias>` is a TUI. For agents, use OpenSSH with the **same Host
+alias**:
+
+```bash
+scp prod-web:/var/log/nginx/error.log /tmp/
+scp ./deploy.sh prod-web:/tmp/
+rsync -az ./out/ prod-web:/opt/app/
+sftp prod-web
+```
+
+Do not send files to `~/Downloads/ctty` unless the user asked; put them where
+the task needs them. `sftp` without a batch file is still interactive — prefer
+`scp`/`rsync`.
+
+### 5. Telnet
+
+Saved devices: `~/.config/ctty/telnet.json` (Windows: `%APPDATA%\ctty\telnet.json`).
+List with `jq`; do not start a session.
+
+```bash
+jq '.hosts[] | {name, host, port, tags}' ~/.config/ctty/telnet.json
+```
+
+Connect commands for the human (cleartext; prefer SSH if the box has it):
+
+```text
+ctty telnet core-sw          # saved name
+ctty telnet 192.168.1.1      # port 23
+ctty telnet 10.0.0.5:2001    # explicit port
+```
+
+Disconnect: `Ctrl+]`. Missing file ⇒ no saved devices, not an error.
+
+### 6. Serial
+
+Saved devices: `~/.config/ctty/serial.json`. Auto-detected ports only appear
+inside the TUI.
+
+```bash
+jq '.devices[] | {name, device, baud_rate, data_bits, parity, stop_bits}' ~/.config/ctty/serial.json
+```
+
+There is no `ctty serial <name>` CLI. Tell the user to run `ctty serial` and
+pick the device. Disconnect: `Ctrl+]` or `Ctrl+C`.
+
+### 7. Import (Tabby → SSH)
+
+Non-interactive. Always dry-run first. Secrets in the source app are **not**
+imported.
+
+```bash
+ctty --lang en --no-update-check import tabby --dry-run
+ctty --lang en --no-update-check import --from tabby
+ctty --lang en --no-update-check import tabby -f /path/to/tabby/config.yaml
+```
+
+Writes `~/.ssh/config.d/tabby.conf` and may add an `Include`. Existing Host
+names are skipped.
+
+## Do not
+
+| Request | Agent does | Human does |
+|---------|------------|------------|
+| "SSH into prod" | `info` + remote commands, or quote `ctty prod` | Interactive SSH |
+| "SFTP / copy files" | `scp`/`rsync` with the alias | `ctty sftp host` |
+| "Telnet to the switch" | List `telnet.json`, quote `ctty telnet <name>` | Interactive telnet |
+| "Open serial / console" | List `serial.json`, quote `ctty serial` | Serial TUI |
+| "Port forward" | Explain `-L`/`-R`/`-D`; do not open TUI | `f` in the host list |
+| "Add a host" | Append a `Host` block (see [reference.md](references/reference.md)) | `ctty add` |
+| "Import Tabby" | `import tabby --dry-run`, then import if asked | Confirm result |
+
+Do not treat Cobra subcommand names as SSH hosts: `add`, `edit`, `move`,
+`search`, `info`, `sftp`, `serial`, `telnet`, `import`, `update`, `completion`.
+
+## Examples
+
+**User:** "prod 那台磁盘还有多少"
+
+```bash
+ctty --lang en --no-update-check search --format json prod
+# if exactly one host, e.g. prod-web:
+ctty --lang en --no-update-check prod-web -- df -h
+```
+
+**User:** "查一下 web 机器的 nginx 是否在跑"
+
+```bash
+ctty --lang en --no-update-check search --format json '#web'
+ctty --lang en --no-update-check web-01 -- systemctl is-active nginx
+```
+
+**User:** "连上 Netease"
+
+Quote: `ctty Netease`. Do not execute it.
+
+**User:** "连实验室那台 telnet 交换机"
+
+```bash
+jq '.hosts[] | {name, host, port, tags}' ~/.config/ctty/telnet.json
+```
+
+Then quote `ctty telnet core-sw` (or whatever `name` matched). Do not run it.
+
+**User:** "串口连交换机"
+
+```bash
+jq '.devices[]' ~/.config/ctty/serial.json
+```
+
+Then quote `ctty serial`.
+
+## Additional resources
+
+- [reference.md](references/reference.md) — JSON shapes, serial/telnet stores, SSH tags, flags, pitfalls

--- a/skills/ctty/references/reference.md
+++ b/skills/ctty/references/reference.md
@@ -1,0 +1,212 @@
+# ctty CLI reference
+
+ctty is SSH + serial + telnet + SFTP. Only SSH `search` / `info` / remote-exec
+and `import` are non-interactive CLIs. Serial/telnet inventories are JSON files.
+
+## Persistent flags (all commands)
+
+| Flag | Meaning |
+|------|---------|
+| `--lang en` | English messages (also `zh`, `auto`) |
+| `--no-update-check` | Skip GitHub version check |
+| `-c path` | SSH config file instead of `~/.ssh/config` |
+
+Root also has `-t` / `--tty` (force TTY on `ctty <host> <cmd>`) and
+`-s` / `--search` (TUI — do not use).
+
+## `ctty search`
+
+```bash
+ctty search [query] [--format json|simple|table] [--tags] [--names]
+```
+
+JSON is an array of objects:
+
+```json
+[
+  {
+    "name": "prod-web",
+    "hostname": "10.0.0.10",
+    "user": "deploy",
+    "port": "2222",
+    "identity": "~/.ssh/id_prod",
+    "proxy_jump": "bastion",
+    "proxy_command": "",
+    "options": "",
+    "tags": ["prod", "web"]
+  }
+]
+```
+
+`port` is a **string** here (may be empty). Empty strings mean unset.
+
+`--tags` searches tags only; `--names` searches Host aliases only.
+Default searches name + hostname + tags. Query words are AND.
+Case-insensitive. `#tag` and `tag` both match.
+
+Hidden hosts are filtered out before search.
+
+## `ctty info <alias>`
+
+One JSON object, schema `ctty.info.v1`.
+
+Success (`ok: true`, exit 0):
+
+```json
+{
+  "schema": "ctty.info.v1",
+  "ok": true,
+  "hostname": "prod-web",
+  "result": {
+    "canonical_name": "prod-web",
+    "target": {
+      "host": "prod-web",
+      "hostname": "10.0.0.10",
+      "user": "deploy",
+      "port": 2222
+    },
+    "identity_file": "~/.ssh/id_prod",
+    "proxy_jump": "bastion",
+    "proxy_command": null,
+    "options": "ServerAliveInterval 60",
+    "tags": ["prod", "web"],
+    "remote_command": null,
+    "request_tty": null,
+    "source": { "file": "/Users/you/.ssh/config", "line": 12 }
+  },
+  "error": null
+}
+```
+
+`target.port` is a **number** or omitted. Optional strings are `null` when unset.
+
+Not found (`ok: false`, exit 2):
+
+```json
+{
+  "schema": "ctty.info.v1",
+  "ok": false,
+  "hostname": "missing",
+  "result": null,
+  "error": { "code": "NOT_FOUND", "message": "...", "details": null }
+}
+```
+
+`error.code`: `NOT_FOUND` | `CONFIG_ERROR`.
+
+`info` **does** resolve hidden hosts. Use it when search omitted an alias
+the user named explicitly.
+
+## Remote exec
+
+```
+ctty [global flags] [-t] <alias> [--] <remote command...>
+```
+
+Uses `ssh` under the hood with the user's config (`-F` if `-c` was passed).
+If a password is stored in ctty's vault, ASKPASS is injected automatically.
+
+Exit code = remote process exit code (or 1 if the alias does not exist).
+
+Unknown Cobra "commands" are treated as host aliases (`ctty mybox` tries to
+SSH to `mybox`). That is why a bare alias is interactive — never run it
+unattended.
+
+## Serial store (`serial.json`)
+
+```json
+{
+  "devices": [
+    {
+      "name": "Switch-Console",
+      "device": "/dev/cu.usbserial-1420",
+      "baud_rate": 115200,
+      "data_bits": 8,
+      "parity": "none",
+      "stop_bits": 1,
+      "flow_control": "none"
+    }
+  ]
+}
+```
+
+No CLI to list or connect by name. Missing file = empty list. Newly plugged
+ports that are not saved only show up in `ctty serial`.
+
+## Telnet store (`telnet.json`)
+
+```json
+{
+  "hosts": [
+    {
+      "name": "core-sw",
+      "host": "192.168.1.1",
+      "port": 23,
+      "tags": ["lab"]
+    }
+  ]
+}
+```
+
+`ctty telnet <name>` matches `name` first, else parses `host[:port]`
+(default 23; bracketed IPv6 ok). Still an interactive bridge — do not run it
+unattended. Missing file = empty list.
+
+## Config files (read, don't rummage secrets)
+
+| Path | Role |
+|------|------|
+| `~/.ssh/config` and `Include` | SSH Host aliases |
+| `~/.config/ctty/config.json` | language, updates, keybindings, tag colors |
+| `~/.config/ctty/telnet.json` | saved telnet devices |
+| `~/.config/ctty/serial.json` | saved serial devices |
+| `~/.config/ctty/snippets.json` | TUI remote-exec snippets (not used by CLI exec) |
+| `~/.config/ctty/credentials.json` | **encrypted SSH passwords — do not read or copy** |
+| `~/.config/ctty/backups/` | last SSH config backup after a ctty mutation |
+
+Windows: `%APPDATA%\ctty\` instead of `~/.config/ctty/`.
+
+### SSH Host block (for adding a host without TUI)
+
+Write above the `Host` line. Tags are comments, not SSH keywords.
+The special tag `hidden` hides the host from TUI/search.
+
+```ssh
+# Tags: prod, web
+Host prod-web
+    HostName 10.0.0.10
+    User deploy
+    Port 22
+    IdentityFile ~/.ssh/id_prod
+    ProxyJump bastion
+```
+
+Prefer appending to an `Include`d file (e.g. `~/.ssh/config.d/`) if one
+exists, so the main config stays small. Do not store passwords here.
+
+ctty backups the file it rewrites; a manual edit does not. Copy first if
+you are changing a live config.
+
+## Import / update (rarely for agents)
+
+```bash
+ctty import tabby --dry-run
+ctty import --from tabby
+ctty update          # check only
+```
+
+`import` writes `~/.ssh/config.d/tabby.conf` and may add an `Include`.
+Always `--dry-run` first. Do not run `ctty update --yes` unless asked.
+
+## Pitfalls
+
+- Search JSON `port` is a string; info JSON `target.port` is a number.
+- Table search output is localized and colorized — not for scripts.
+- `ctty search` with zero config hosts exits 1; zero *matches* exits 0.
+- Alias `info` / `search` / `add` / `serial` / `telnet` / … cannot be used as
+  `ctty <host>`.
+- First SSH to a new host from TUI uses `StrictHostKeyChecking=accept-new`.
+  CLI `ctty <host> cmd` uses stock OpenSSH host-key behavior — a new host
+  may prompt; in a non-TTY that fails. Don't loop on that; report it.
+- `ctty telnet <arg>` is never a one-shot probe; it attaches a raw terminal.
+- Serial has no named CLI connect; `ctty serial` is always the manager TUI.


### PR DESCRIPTION
- Introduced new sections in README and README_CN for teaching agents to use ctty, including installation commands and usage examples.
- Added SKILL.md and reference.md files to provide detailed guidance on ctty's CLI capabilities and configuration.
- Updated .gitignore to specify project-specific binary exclusions more clearly.