### PR TITLE
fix(sftp): transfer cancel deadlock (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.6.1] - 2026-09-03
+
+### Fixed
+
+- **SFTP transfer cancel deadlock** — Pressing ESC during an upload/download now truly cancels the in-flight goroutine via `context.WithCancel`, releasing the SFTP session mutex immediately. Previously the goroutine kept running and held the lock, so subsequent ESC (exit) or any directory operation would deadlock the entire TUI.
+
 ## [0.6.0] - 2026-09-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [0.6.1] - 2026-09-03
 
+### Added
+
+- **Agent Skill (`skills/ctty/`)** — Cursor / Claude Code / Codex agent skill with full non-interactive usage guide, install commands, workflow checklists, and JSON reference. Lets AI agents drive ctty's CLI (search, info, remote exec, import) without launching the TUI.
+
 ### Fixed
 
 - **SFTP transfer cancel deadlock** — Pressing ESC during an upload/download now truly cancels the in-flight goroutine via `context.WithCancel`, releasing the SFTP session mutex immediately. Previously the goroutine kept running and held the lock, so subsequent ESC (exit) or any directory operation would deadlock the entire TUI.

--- a/internal/sftpconfig/sftp.go
+++ b/internal/sftpconfig/sftp.go
@@ -1,6 +1,7 @@
 package sftpconfig
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/fs"
@@ -371,6 +372,11 @@ func (c *SFTPClient) Download(remotePath, localPath string) error {
 // DownloadWithProgress downloads a remote file with a progress callback.
 // The callback receives bytes downloaded and total size.
 func (c *SFTPClient) DownloadWithProgress(remotePath, localPath string, progress func(downloaded, total int64)) error {
+	return c.DownloadWithProgressCtx(context.Background(), remotePath, localPath, progress)
+}
+
+// DownloadWithProgressCtx is like DownloadWithProgress but accepts a context for cancellation.
+func (c *SFTPClient) DownloadWithProgressCtx(ctx context.Context, remotePath, localPath string, progress func(downloaded, total int64)) error {
 	return c.withSession(func(sc *sftpWrapper) error {
 		remoteFile, err := sc.Open(remotePath)
 		if err != nil {
@@ -393,6 +399,11 @@ func (c *SFTPClient) DownloadWithProgress(remotePath, localPath string, progress
 		buf := make([]byte, 32*1024)
 		var downloaded int64
 		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			n, err := remoteFile.Read(buf)
 			if n > 0 {
 				if _, werr := localFile.Write(buf[:n]); werr != nil {
@@ -416,6 +427,11 @@ func (c *SFTPClient) DownloadWithProgress(remotePath, localPath string, progress
 
 // UploadWithProgress uploads a local file with a progress callback.
 func (c *SFTPClient) UploadWithProgress(localPath, remotePath string, progress func(uploaded, total int64)) error {
+	return c.UploadWithProgressCtx(context.Background(), localPath, remotePath, progress)
+}
+
+// UploadWithProgressCtx is like UploadWithProgress but accepts a context for cancellation.
+func (c *SFTPClient) UploadWithProgressCtx(ctx context.Context, localPath, remotePath string, progress func(uploaded, total int64)) error {
 	return c.withSession(func(sc *sftpWrapper) error {
 		localFile, err := os.Open(localPath)
 		if err != nil {
@@ -438,6 +454,11 @@ func (c *SFTPClient) UploadWithProgress(localPath, remotePath string, progress f
 		buf := make([]byte, 32*1024)
 		var uploaded int64
 		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			n, err := localFile.Read(buf)
 			if n > 0 {
 				if _, werr := remoteFile.Write(buf[:n]); werr != nil {

--- a/internal/ui/sftp_view.go
+++ b/internal/ui/sftp_view.go
@@ -1,6 +1,7 @@
 package ui
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -55,6 +56,7 @@ type sftpFormModel struct {
 	progressFile  string
 	progressGen   int
 	transferring  bool
+	transferCancel context.CancelFunc // cancels the in-flight upload/download goroutine
 	queue         sftpTransferQueue
 
 	// For input modes
@@ -245,6 +247,13 @@ func (m *sftpFormModel) handleTransferResult(gen int, filename string, success b
 	return m.loadDirCmd(m.cwd)
 }
 
+func (m *sftpFormModel) cancelTransfer() {
+	if m.transferCancel != nil {
+		m.transferCancel()
+		m.transferCancel = nil
+	}
+}
+
 func (m *sftpFormModel) downloadCmd(remotePath, localPath string) tea.Cmd {
 	filename := filepath.Base(remotePath)
 	m.progressGen++
@@ -253,11 +262,17 @@ func (m *sftpFormModel) downloadCmd(remotePath, localPath string) tea.Cmd {
 	m.progressDone = 0
 	m.progressTotal = 0
 
+	ctx, cancel := context.WithCancel(context.Background())
+	m.transferCancel = cancel
+
 	download := func() tea.Msg {
-		err := m.client.DownloadWithProgress(remotePath, localPath, func(downloaded, total int64) {
+		err := m.client.DownloadWithProgressCtx(ctx, remotePath, localPath, func(downloaded, total int64) {
 			m.progressDone = downloaded
 			m.progressTotal = total
 		})
+		if ctx.Err() != nil {
+			return sftpDownloadResultMsg{gen: gen, filename: filename, success: false, err: ctx.Err()}
+		}
 		return sftpDownloadResultMsg{gen: gen, filename: filename, success: err == nil, err: err}
 	}
 
@@ -277,11 +292,17 @@ func (m *sftpFormModel) uploadCmd(localPath, remotePath string) tea.Cmd {
 	m.progressDone = 0
 	m.progressTotal = 0
 
+	ctx, cancel := context.WithCancel(context.Background())
+	m.transferCancel = cancel
+
 	upload := func() tea.Msg {
-		err := m.client.UploadWithProgress(localPath, remotePath, func(uploaded, total int64) {
+		err := m.client.UploadWithProgressCtx(ctx, localPath, remotePath, func(uploaded, total int64) {
 			m.progressDone = uploaded
 			m.progressTotal = total
 		})
+		if ctx.Err() != nil {
+			return sftpUploadResultMsg{gen: gen, filename: filename, success: false, err: ctx.Err()}
+		}
 		return sftpUploadResultMsg{gen: gen, filename: filename, success: err == nil, err: err}
 	}
 
@@ -472,6 +493,7 @@ func (m *sftpFormModel) handleBrowseKeys(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch key {
 	case "esc", "q":
 		if m.transferring || (m.loading && m.client != nil) {
+			m.cancelTransfer()
 			m.loading = false
 			m.transferring = false
 			m.progressGen++
@@ -826,6 +848,7 @@ func (m *sftpFormModel) handleUploadSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) 
 	switch key {
 	case "esc", "tab", "shift+tab":
 		if m.transferring {
+			m.cancelTransfer()
 			m.loading = false
 			m.transferring = false
 			m.progressGen++


### PR DESCRIPTION
Closes #8 

## Summary

Major feature release adding four new capabilities and several bug fixes.

### ✨ New Features

- **Agent Skill** (`skills/ctty/`) — Non-interactive usage guide for AI agents (Cursor / Claude Code / Copilot CLI) with workflow checklists and JSON reference.

### 🐛 Bug Fixes

- **SFTP transfer cancel deadlock** — ESC now cancels the in-flight goroutine via `context.WithCancel`, releasing the SFTP session mutex. Previously the goroutine held the lock, causing the TUI to freeze on exit.
