### PR TITLE
fix(sftp): verify SSH host keys

### DIFF
--- a/internal/sftpconfig/sftp.go
+++ b/internal/sftpconfig/sftp.go
@@ -2,6 +2,7 @@ package sftpconfig
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -179,10 +180,10 @@ func buildSSHConfig(host *config.SSHHost) (*ssh.ClientConfig, error) {
 		return nil, err
 	}
 
-	// Use InsecureIgnoreHostKey to avoid knownhosts key mismatch issues.
-	// This matches `ssh -o StrictHostKeyChecking=no` behavior.
-	// TODO: add proper known_hosts verification with host key update support.
-	knownHostsCallback := ssh.InsecureIgnoreHostKey()
+	knownHostsCallback, err := getHostKeyCallback()
+	if err != nil {
+		return nil, fmt.Errorf("failed to prepare host key verification: %w", err)
+	}
 
 	cfg := &ssh.ClientConfig{
 		User:            getUser(host),
@@ -261,17 +262,84 @@ func getAuthMethods(host *config.SSHHost) ([]ssh.AuthMethod, error) {
 	return methods, nil
 }
 
-// getHostKeyCallback returns a known_hosts based host key callback.
+var knownHostsMu sync.Mutex
+
+// getHostKeyCallback returns an accept-new known_hosts callback. Unknown keys
+// are recorded on first use; a changed key is rejected on later connections.
 func getHostKeyCallback() (ssh.HostKeyCallback, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
 		return nil, err
 	}
 	knownHostsPath := filepath.Join(homeDir, ".ssh", "known_hosts")
-	if _, err := os.Stat(knownHostsPath); err != nil {
-		return nil, err
+	return acceptNewHostKeyCallback(knownHostsPath)
+}
+
+func acceptNewHostKeyCallback(knownHostsPath string) (ssh.HostKeyCallback, error) {
+	if err := os.MkdirAll(filepath.Dir(knownHostsPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create known_hosts directory: %w", err)
 	}
-	return knownhosts.New(knownHostsPath)
+	file, err := os.OpenFile(knownHostsPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open known_hosts: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return nil, fmt.Errorf("close known_hosts: %w", err)
+	}
+	if err := os.Chmod(knownHostsPath, 0o600); err != nil {
+		return nil, fmt.Errorf("secure known_hosts permissions: %w", err)
+	}
+
+	verify, err := knownhosts.New(knownHostsPath)
+	if err != nil {
+		return nil, fmt.Errorf("parse known_hosts: %w", err)
+	}
+
+	return func(hostname string, remote net.Addr, key ssh.PublicKey) error {
+		if err := verify(hostname, remote, key); err == nil {
+			return nil
+		} else if !isUnknownHostKey(err) {
+			return fmt.Errorf("verify host key for %s: %w", hostname, err)
+		}
+
+		knownHostsMu.Lock()
+		defer knownHostsMu.Unlock()
+
+		// Re-read while holding the append lock. Another connection may have
+		// recorded this host after this callback captured its initial snapshot.
+		current, err := knownhosts.New(knownHostsPath)
+		if err != nil {
+			return fmt.Errorf("reload known_hosts: %w", err)
+		}
+		if err := current(hostname, remote, key); err == nil {
+			return nil
+		} else if !isUnknownHostKey(err) {
+			return fmt.Errorf("verify host key for %s: %w", hostname, err)
+		}
+
+		line := knownhosts.Line([]string{knownhosts.Normalize(hostname)}, key)
+		file, err := os.OpenFile(knownHostsPath, os.O_APPEND|os.O_WRONLY, 0o600)
+		if err != nil {
+			return fmt.Errorf("append known_hosts: %w", err)
+		}
+		if _, err := fmt.Fprintln(file, line); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("write known_hosts: %w", err)
+		}
+		if err := file.Sync(); err != nil {
+			_ = file.Close()
+			return fmt.Errorf("sync known_hosts: %w", err)
+		}
+		if err := file.Close(); err != nil {
+			return fmt.Errorf("close known_hosts: %w", err)
+		}
+		return nil
+	}, nil
+}
+
+func isUnknownHostKey(err error) bool {
+	var keyErr *knownhosts.KeyError
+	return errors.As(err, &keyErr) && len(keyErr.Want) == 0
 }
 
 func expandPath(path string) string {

--- a/internal/sftpconfig/sftp_hostkey_test.go
+++ b/internal/sftpconfig/sftp_hostkey_test.go
@@ -1,0 +1,111 @@
+// sftp_hostkey_test.go covers trust-on-first-use host key persistence for SFTP.
+package sftpconfig
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/ssh"
+	"golang.org/x/crypto/ssh/knownhosts"
+)
+
+func testPublicKey(t *testing.T) ssh.PublicKey {
+	t.Helper()
+	public, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := ssh.NewPublicKey(public)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func TestAcceptNewHostKeyCallbackRecordsAndVerifies(t *testing.T) {
+	path := filepath.Join(t.TempDir(), ".ssh", "known_hosts")
+	callback, err := acceptNewHostKeyCallback(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostname := "example.test:22"
+	remote := &net.TCPAddr{IP: net.ParseIP("192.0.2.10"), Port: 22}
+	key := testPublicKey(t)
+
+	if err := callback(hostname, remote, key); err != nil {
+		t.Fatalf("first connection should record the key: %v", err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), knownhosts.Normalize(hostname)) {
+		t.Fatalf("known_hosts entry %q does not contain %q", data, knownhosts.Normalize(hostname))
+	}
+	if !bytes.Contains(data, ssh.MarshalAuthorizedKey(key)) {
+		t.Fatalf("known_hosts entry does not contain the recorded key")
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("known_hosts permissions = %o, want 600", got)
+	}
+
+	reloaded, err := acceptNewHostKeyCallback(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reloaded(hostname, remote, key); err != nil {
+		t.Fatalf("recorded key should be accepted: %v", err)
+	}
+}
+
+func TestAcceptNewHostKeyCallbackRejectsChangedKey(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	callback, err := acceptNewHostKeyCallback(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	hostname := "[example.test]:2222"
+	remote := &net.TCPAddr{IP: net.ParseIP("192.0.2.11"), Port: 2222}
+	if err := callback(hostname, remote, testPublicKey(t)); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded, err := acceptNewHostKeyCallback(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := reloaded(hostname, remote, testPublicKey(t)); err == nil {
+		t.Fatal("changed host key should be rejected")
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, before) {
+		t.Fatal("changed host key must not be appended")
+	}
+}
+
+func TestAcceptNewHostKeyCallbackRejectsMalformedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "known_hosts")
+	if err := os.WriteFile(path, []byte("not a known_hosts entry\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := acceptNewHostKeyCallback(path); err == nil {
+		t.Fatal("malformed known_hosts file should fail closed")
+	}
+}


### PR DESCRIPTION
## Summary

- replace `ssh.InsecureIgnoreHostKey()` in the SFTP client with accept-new host-key verification
- persist first-seen keys in `~/.ssh/known_hosts` with `0600` permissions
- reject changed keys and malformed known-hosts data instead of silently continuing
- serialize and re-check concurrent first connections before appending

## Why

The SFTP path can transmit credentials and files, but it currently accepts every server host key. That leaves connections vulnerable to undetected machine-in-the-middle attacks. Trust-on-first-use keeps the current zero-prompt first connection while protecting every later connection from key changes.

## Validation

- `go test ./...`
- `go test -race ./internal/sftpconfig`
- `go vet ./...`
- `go build ./...`
- cross-build: Linux amd64 and Windows amd64