### PR TITLE
fix(install): verify release checksums

### DIFF
--- a/install/unix.sh
+++ b/install/unix.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-INSTALL_DIR="/usr/local/bin"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 EXECUTABLE_NAME=ctty
 EXECUTABLE_PATH="$INSTALL_DIR/$EXECUTABLE_NAME"
 USE_SUDO="false"
@@ -8,6 +8,8 @@ OS=""
 ARCH=""
 FORCE_INSTALL="${FORCE_INSTALL:-false}"
 CTTY_VERSION="${CTTY_VERSION:-latest}"
+TEMP_DIR=""
+DOWNLOADED_BINARY=""
 
 RED='\033[0;31m'
 PURPLE='\033[0;35m'
@@ -16,9 +18,9 @@ YELLOW='\033[1;33m'
 NC='\033[0m'
 
 # detect Termux： make sure $PREFIX exist com.termux or $TERMUX_VERSION
-if [ -n "$PREFIX" ] && [ -d "/data/data/com.termux" ] 2>/dev/null || [ -n "$TERMUX_VERSION" ]; then
+if { [ -n "${PREFIX:-}" ] && [ -d "/data/data/com.termux" ]; } || [ -n "${TERMUX_VERSION:-}" ]; then
     IS_TERMUX="true"
-    INSTALL_DIR="$PREFIX/bin"
+    INSTALL_DIR="${PREFIX:-/data/data/com.termux/files/usr}/bin"
     EXECUTABLE_PATH="$INSTALL_DIR/$EXECUTABLE_NAME"
 else
     IS_TERMUX="false"
@@ -62,12 +64,64 @@ setSystem() {
 }
 
 runAsRoot() {
-    local CMD="$*"
     if [ "$USE_SUDO" = "true" ]; then
         printf "${PURPLE}We need sudo access to install ctty to $INSTALL_DIR ${NC}\n"
-        CMD="sudo $CMD"
+        sudo "$@"
+    else
+        "$@"
     fi
-    $CMD
+}
+
+sha256File() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$1" | awk '{print $NF}'
+    else
+        printf "${RED}No SHA-256 tool found (sha256sum, shasum, or openssl required)${NC}\n" >&2
+        return 1
+    fi
+}
+
+verifyChecksum() {
+    local ARCHIVE_PATH="$1"
+    local CHECKSUMS_PATH="$2"
+    local ASSET_NAME="$3"
+    local EXPECTED
+    local ACTUAL
+
+    if ! EXPECTED=$(awk -v asset="$ASSET_NAME" '
+        $2 == asset {
+            if (found) {
+                exit 2
+            }
+            expected = $1
+            found = 1
+        }
+        END {
+            if (!found) {
+                exit 1
+            }
+            print expected
+        }
+    ' "$CHECKSUMS_PATH"); then
+        printf "${RED}No unique checksum found for $ASSET_NAME${NC}\n" >&2
+        return 1
+    fi
+    if ! printf '%s' "$EXPECTED" | grep -Eq '^[[:xdigit:]]{64}$'; then
+        printf "${RED}No valid SHA-256 checksum found for $ASSET_NAME${NC}\n" >&2
+        return 1
+    fi
+    ACTUAL=$(sha256File "$ARCHIVE_PATH") || return 1
+    EXPECTED=$(printf '%s' "$EXPECTED" | tr '[:upper:]' '[:lower:]')
+    ACTUAL=$(printf '%s' "$ACTUAL" | tr '[:upper:]' '[:lower:]')
+    if [ "$ACTUAL" != "$EXPECTED" ]; then
+        printf "${RED}Checksum verification failed for $ASSET_NAME${NC}\n" >&2
+        return 1
+    fi
+    printf "${GREEN}Checksum verified.${NC}\n"
 }
 
 getLatestVersion() {
@@ -114,31 +168,38 @@ downloadBinary() {
     # GoReleaser format: ctty_Linux_armv7.tar.gz
     GITHUB_FILE="ctty_${GORELEASER_OS}_${GORELEASER_ARCH}.tar.gz"
     GITHUB_URL="https://github.com/zsuroy/ctty/releases/download/$LATEST_VERSION/$GITHUB_FILE"
+    CHECKSUMS_URL="https://github.com/zsuroy/ctty/releases/download/$LATEST_VERSION/checksums.txt"
+    ARCHIVE_PATH="$TEMP_DIR/$GITHUB_FILE"
+    CHECKSUMS_PATH="$TEMP_DIR/checksums.txt"
     
     printf "${YELLOW}Downloading $GITHUB_FILE...${NC}\n"
-    curl -L "$GITHUB_URL" --progress-bar --output "ctty-tmp.tar.gz"
-    
-    if [ $? -ne 0 ]; then
+    if ! curl --fail --location --proto '=https' --tlsv1.2 "$GITHUB_URL" --progress-bar --output "$ARCHIVE_PATH"; then
         printf "${RED}Failed to download binary${NC}\n"
+        exit 1
+    fi
+
+    printf "${YELLOW}Downloading release checksums...${NC}\n"
+    if ! curl --fail --location --proto '=https' --tlsv1.2 "$CHECKSUMS_URL" --silent --show-error --output "$CHECKSUMS_PATH"; then
+        printf "${RED}Failed to download release checksums${NC}\n"
+        exit 1
+    fi
+    if ! verifyChecksum "$ARCHIVE_PATH" "$CHECKSUMS_PATH" "$GITHUB_FILE"; then
         exit 1
     fi
     
     # Extract the binary
-    tar -xzf "ctty-tmp.tar.gz"
-    if [ $? -ne 0 ]; then
+    if ! tar -xzf "$ARCHIVE_PATH" -C "$TEMP_DIR"; then
         printf "${RED}Failed to extract binary${NC}\n"
         exit 1
     fi
     
     # GoReleaser extracts the binary as just "ctty", not with the platform suffix
-    EXTRACTED_BINARY="./ctty"
+    EXTRACTED_BINARY="$TEMP_DIR/ctty"
     if [ ! -f "$EXTRACTED_BINARY" ]; then
         printf "${RED}Could not find extracted binary: $EXTRACTED_BINARY${NC}\n"
         exit 1
     fi
-    
-    mv "$EXTRACTED_BINARY" "ctty-tmp"
-    rm -f "ctty-tmp.tar.gz"
+    DOWNLOADED_BINARY="$EXTRACTED_BINARY"
 }
 
 install() {
@@ -151,8 +212,7 @@ install() {
         runAsRoot mv "$EXECUTABLE_PATH" "$OLD_BACKUP"
     fi
     
-    chmod +x "ctty-tmp"
-    if [ $? -ne 0 ]; then
+    if ! chmod +x "$DOWNLOADED_BINARY"; then
         printf "${RED}Failed to set permissions${NC}\n"
         # Restore backup if installation fails
         if [ -n "$OLD_BACKUP" ] && [ -f "$OLD_BACKUP" ]; then
@@ -161,8 +221,7 @@ install() {
         exit 1
     fi
 
-    runAsRoot mv "ctty-tmp" "$EXECUTABLE_PATH"
-    if [ $? -ne 0 ]; then
+    if ! runAsRoot mv "$DOWNLOADED_BINARY" "$EXECUTABLE_PATH"; then
         printf "${RED}Failed to install binary${NC}\n"
         # Restore backup if installation fails
         if [ -n "$OLD_BACKUP" ] && [ -f "$OLD_BACKUP" ]; then
@@ -178,7 +237,9 @@ install() {
 }
 
 cleanup() {
-    rm -f "ctty-tmp" "ctty-tmp.tar.gz" "ctty-${OS}-${ARCH}"
+    if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
+        rm -rf -- "$TEMP_DIR"
+    fi
 }
 
 checkExisting() {
@@ -235,6 +296,12 @@ main() {
     
     # Check if already installed (this might prompt user)
     checkExisting
+
+    TEMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ctty-install.XXXXXX") || {
+        printf "${RED}Failed to create a temporary directory${NC}\n"
+        exit 1
+    }
+    trap cleanup EXIT
     
     # Download and install
     downloadBinary
@@ -254,7 +321,6 @@ main() {
     fi
 }
 
-# Trap to cleanup on exit
-trap cleanup EXIT
-
-main "$@"
+if [ "${CTTY_INSTALL_TESTING:-false}" != "true" ]; then
+    main "$@"
+fi

--- a/install/unix_test.sh
+++ b/install/unix_test.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+CTTY_INSTALL_TESTING=true
+export CTTY_INSTALL_TESTING
+# shellcheck source=unix.sh
+. "$SCRIPT_DIR/unix.sh"
+
+TEST_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ctty-install-test.XXXXXX")
+trap 'rm -rf -- "$TEST_DIR"' EXIT
+
+ASSET="ctty_Linux_x86_64.tar.gz"
+ARCHIVE="$TEST_DIR/$ASSET"
+CHECKSUMS="$TEST_DIR/checksums.txt"
+printf 'verified archive' > "$ARCHIVE"
+DIGEST=$(sha256File "$ARCHIVE")
+printf '%s  %s\n' "$DIGEST" "$ASSET" > "$CHECKSUMS"
+
+verifyChecksum "$ARCHIVE" "$CHECKSUMS" "$ASSET" >/dev/null
+
+printf '%s  %s\n%s  %s\n' "$DIGEST" "$ASSET" "$DIGEST" "$ASSET" > "$CHECKSUMS"
+if verifyChecksum "$ARCHIVE" "$CHECKSUMS" "$ASSET" >/dev/null 2>&1; then
+    printf 'duplicate checksums unexpectedly passed validation\n' >&2
+    exit 1
+fi
+
+printf '%s  %s\n' "$DIGEST" "$ASSET" > "$CHECKSUMS"
+printf 'tampered archive' > "$ARCHIVE"
+if verifyChecksum "$ARCHIVE" "$CHECKSUMS" "$ASSET" >/dev/null 2>&1; then
+    printf 'tampered archive unexpectedly passed checksum verification\n' >&2
+    exit 1
+fi
+
+printf 'not-a-digest  %s\n' "$ASSET" > "$CHECKSUMS"
+if verifyChecksum "$ARCHIVE" "$CHECKSUMS" "$ASSET" >/dev/null 2>&1; then
+    printf 'invalid checksum unexpectedly passed validation\n' >&2
+    exit 1
+fi

--- a/install/windows.ps1
+++ b/install/windows.ps1
@@ -67,56 +67,67 @@ if ($LocalBinary -ne "") {
 } else {
     # Online installation
     Write-Info "Starting online installation..."
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("ctty-install-" + [guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
     
-    # Get latest version
-    Write-Info "Fetching latest version..."
     try {
-        $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/zsuroy/ctty/releases/latest"
-        $latestVersion = $latestRelease.tag_name
-        Write-Info "Target version: $latestVersion"
-    } catch {
-        Write-Error "Failed to fetch version information"
-        exit 1
-    }
+        # Get latest version
+        Write-Info "Fetching latest version..."
+        try {
+            $latestRelease = Invoke-RestMethod -Uri "https://api.github.com/repos/zsuroy/ctty/releases/latest"
+            $latestVersion = $latestRelease.tag_name
+            Write-Info "Target version: $latestVersion"
+        } catch {
+            throw "Failed to fetch version information: $($_.Exception.Message)"
+        }
 
-    # Download binary
-    # Map architecture to match GoReleaser format
-    $goreleaserArch = if ($arch -eq "amd64") { "x86_64" } else { "i386" }
-    
-    # GoReleaser format: ctty_Windows_x86_64.zip
-    $fileName = "ctty_Windows_$goreleaserArch.zip"
-    $downloadUrl = "https://github.com/zsuroy/ctty/releases/download/$latestVersion/$fileName"
-    $tempFile = "$env:TEMP\$fileName"
+        # Download binary and the GoReleaser checksum manifest.
+        $goreleaserArch = if ($arch -eq "amd64") { "x86_64" } else { "i386" }
+        $fileName = "ctty_Windows_$goreleaserArch.zip"
+        $releaseBase = "https://github.com/zsuroy/ctty/releases/download/$latestVersion"
+        $downloadUrl = "$releaseBase/$fileName"
+        $tempFile = Join-Path $tempDir $fileName
+        $checksumsFile = Join-Path $tempDir "checksums.txt"
 
-    Write-Info "Downloading $fileName..."
-    try {
+        Write-Info "Downloading $fileName..."
         Invoke-WebRequest -Uri $downloadUrl -OutFile $tempFile
-    } catch {
-        Write-Error "Download failed"
-        exit 1
-    }
+        Invoke-WebRequest -Uri "$releaseBase/checksums.txt" -OutFile $checksumsFile
 
-    # Create installation directory
-    if (-not (Test-Path $InstallDir)) {
-        New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
-    }
+        $escapedName = [regex]::Escape($fileName)
+        $checksumLine = @(Get-Content $checksumsFile | Where-Object { $_ -match "^([0-9A-Fa-f]{64})\s+$escapedName$" })
+        if ($checksumLine.Count -ne 1) {
+            throw "No unique SHA-256 checksum found for $fileName"
+        }
+        $expectedChecksum = ($checksumLine[0] -split '\s+')[0]
+        $actualChecksum = (Get-FileHash -Path $tempFile -Algorithm SHA256).Hash
+        if (-not $actualChecksum.Equals($expectedChecksum, [System.StringComparison]::OrdinalIgnoreCase)) {
+            throw "Checksum verification failed for $fileName"
+        }
+        Write-Info "Checksum verified."
 
-    # Extract archive
-    Write-Info "Extracting..."
-    try {
-        Expand-Archive -Path $tempFile -DestinationPath $env:TEMP -Force
+        # Create installation directory
+        if (-not (Test-Path $InstallDir)) {
+            New-Item -ItemType Directory -Path $InstallDir -Force | Out-Null
+        }
+
+        # Extract archive inside this invocation's private temporary directory.
+        Write-Info "Extracting..."
+        $extractDir = Join-Path $tempDir "extracted"
+        Expand-Archive -Path $tempFile -DestinationPath $extractDir -Force
         # GoReleaser extracts the binary as just "ctty.exe", not with platform suffix
-        $extractedBinary = "$env:TEMP\ctty.exe"
+        $extractedBinary = Join-Path $extractDir "ctty.exe"
+        if (-not (Test-Path -LiteralPath $extractedBinary -PathType Leaf)) {
+            throw "Archive does not contain ctty.exe"
+        }
         $targetPath = "$InstallDir\ctty.exe"
         
         Move-Item -Path $extractedBinary -Destination $targetPath -Force
     } catch {
-        Write-Error "Extraction failed"
+        Write-Error $_.Exception.Message
         exit 1
+    } finally {
+        Remove-Item -LiteralPath $tempDir -Recurse -Force -ErrorAction SilentlyContinue
     }
-
-    # Clean up
-    Remove-Item $tempFile -Force
 }
 
 # Check PATH


### PR DESCRIPTION
## Summary

- download the GoReleaser `checksums.txt` alongside Unix and Windows release archives
- require one exact asset entry and verify SHA-256 before extraction
- fail closed on missing, duplicate, malformed, or mismatched checksums
- use a private per-invocation temporary directory to avoid collisions and unsafe working-directory files
- preserve argument boundaries in Unix privileged file operations
- add Unix regression coverage for valid, tampered, duplicate, and malformed checksums

## Why

Both online installers currently execute downloaded release artifacts without checking the checksum file already published by the release workflow. A truncated or altered archive can reach extraction and installation. Shared temporary paths also allow concurrent installs to interfere with one another.

## Validation

- `bash -n install/unix.sh install/unix_test.sh`
- `install/unix_test.sh`
- verified a real v0.6.1 Darwin archive against the published v0.6.1 `checksums.txt`
- `go test ./...`
- `go vet ./...`
- `go build ./...`

The PowerShell path was reviewed but not executed locally because `pwsh` is unavailable on the test host.