### PR TITLE
fix(credential): fail closed on unreadable vaults

### DIFF
--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -35,38 +36,36 @@ type CredentialStore struct {
 
 var (
 	defaultStore *CredentialStore
-	once         sync.Once
+	storeMu      sync.Mutex
 )
 
-// getStore returns the singleton credential store.
+// getStore returns the singleton credential store. Initialization failures are
+// not cached so a repaired config directory or credential file can be retried.
 func getStore() (*CredentialStore, error) {
-	var initErr error
-	once.Do(func() {
-		configDir, err := config.GetcttyConfigDir()
-		if err != nil {
-			initErr = err
-			return
-		}
+	storeMu.Lock()
+	defer storeMu.Unlock()
 
-		filePath := filepath.Join(configDir, "credentials.json")
-		key := deriveMachineKey()
-
-		store := &CredentialStore{
-			credentials: make(map[string]Credential),
-			filePath:    filePath,
-			masterKey:   key,
-		}
-
-		if err := store.load(); err != nil && !os.IsNotExist(err) {
-			// If file exists but corrupt, keep empty store
-		}
-
-		defaultStore = store
-	})
-
-	if initErr != nil {
-		return nil, initErr
+	if defaultStore != nil {
+		return defaultStore, nil
 	}
+
+	configDir, err := config.GetcttyConfigDir()
+	if err != nil {
+		return nil, fmt.Errorf("get credential directory: %w", err)
+	}
+
+	filePath := filepath.Join(configDir, "credentials.json")
+	store := &CredentialStore{
+		credentials: make(map[string]Credential),
+		filePath:    filePath,
+		masterKey:   deriveMachineKey(),
+	}
+
+	if err := store.load(); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("load credential store %s: %w", filePath, err)
+	}
+
+	defaultStore = store
 	return defaultStore, nil
 }
 

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -1,10 +1,24 @@
 package credential
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
 )
+
+func resetDefaultStore(t *testing.T) {
+	t.Helper()
+	storeMu.Lock()
+	previous := defaultStore
+	defaultStore = nil
+	storeMu.Unlock()
+	t.Cleanup(func() {
+		storeMu.Lock()
+		defaultStore = previous
+		storeMu.Unlock()
+	})
+}
 
 func TestEncryptDecrypt(t *testing.T) {
 	key := deriveMachineKey()
@@ -30,6 +44,8 @@ func TestEncryptDecrypt(t *testing.T) {
 }
 
 func TestCredentialStoreOperations(t *testing.T) {
+	resetDefaultStore(t)
+
 	tmpDir, err := os.MkdirTemp("", "ctty-cred-test-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp dir: %v", err)
@@ -45,7 +61,9 @@ func TestCredentialStoreOperations(t *testing.T) {
 		masterKey:   key,
 	}
 
+	storeMu.Lock()
 	defaultStore = store
+	storeMu.Unlock()
 
 	// 1. Set password
 	err = SetPassword("test-host", "mypassword123")
@@ -87,5 +105,54 @@ func TestCredentialStoreOperations(t *testing.T) {
 	_, found = GetPassword("test-host-renamed")
 	if found {
 		t.Fatal("Deleted password should not be found")
+	}
+}
+
+func TestCredentialStoreFailsClosedAndRetriesAfterRepair(t *testing.T) {
+	resetDefaultStore(t)
+
+	configRoot := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configRoot)
+	configDir := filepath.Join(configRoot, "ctty")
+	if err := os.MkdirAll(configDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	vaultPath := filepath.Join(configDir, "credentials.json")
+	corrupt := []byte(`{"host_name":`)
+	if err := os.WriteFile(vaultPath, corrupt, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SetPassword("new-host", "new-password"); err == nil {
+		t.Fatal("SetPassword should reject an unreadable credential vault")
+	}
+	got, err := os.ReadFile(vaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(corrupt) {
+		t.Fatalf("corrupt vault was overwritten: got %q", got)
+	}
+
+	if err := os.WriteFile(vaultPath, []byte("[]"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := SetPassword("new-host", "new-password"); err != nil {
+		t.Fatalf("SetPassword should retry after the vault is repaired: %v", err)
+	}
+
+	data, err := os.ReadFile(vaultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var saved []Credential
+	if err := json.Unmarshal(data, &saved); err != nil {
+		t.Fatalf("saved vault is invalid JSON: %v", err)
+	}
+	if len(saved) != 1 || saved[0].HostName != "new-host" {
+		t.Fatalf("saved credentials = %#v, want new-host", saved)
+	}
+	if password, ok := GetPassword("new-host"); !ok || password != "new-password" {
+		t.Fatalf("GetPassword = %q, %v; want repaired credential", password, ok)
 	}
 }


### PR DESCRIPTION
## Summary

- return credential-store initialization errors instead of replacing unreadable data with an empty in-memory vault
- cache the singleton only after successful initialization
- allow a later call to retry after the credential file or config directory is repaired
- add a regression test proving corrupt JSON is not overwritten and repaired data can be loaded

## Why

When `credentials.json` is corrupt or unreadable, the current code silently initializes an empty store. The next password write can overwrite the damaged vault, turning a recoverable read error into credential loss. The existing `sync.Once` path can also return a nil store after the first initialization failure.

## Validation

- `go test ./...`
- `go test -race ./internal/credential`
- `go vet ./...`
- `go build ./...`
- cross-build: Linux amd64 and Windows amd64