### PR TITLE
feat(cli): add non-interactive agent CLI for SSH, SFTP, serial, and t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- **Agent CLI: non-interactive `add` / `edit`** — Skip Bubble Tea forms when `--non-interactive` is set or any host-config flag is provided (`--name`, `--hostname`, `--user`, `--port`, `--identity-file`, `--proxy-jump`, `--proxy-command`, `--option`/`-o`, `--tags`, `--password`, `--force`). Writes OpenSSH config via the existing backup/validation path; optional `--password` goes to the credential vault only; `--format json` emits a success payload for agents.
+- **Agent CLI: file transfer** — `ctty put <host> <local> <remote>`, `ctty get <host> <remote> <local>`, and `ctty scp` (host:path notation) using the built-in SFTP client; recursive directories; progress on stderr; non-zero exit on failure.
+- **Agent CLI: serial / telnet JSON** — `ctty serial list|search|info` and `ctty telnet list|search|info` with `--format json`. No-args still opens the TUI; `ctty telnet <name>` connect is unchanged.
+- **Agent CLI: batch exec** — `ctty exec --tags prod -- uptime` and/or `--hosts a,b` with `--concurrency` (default 8) and `--format json` array of `{host,ok,exit_code,stdout,stderr}`; aggregate exit 0 iff all succeed.
+
 ## [0.6.1] - 2026-09-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ ctty is a fast, native terminal tool for managing all your connections — SSH h
 ### 🛠️ **Technical Features**
 - **🔒 Secure** - Works directly with your existing `~/.ssh/config` file (credentials stored separately, never pollutes standard SSH configs)
 - **📁 Custom Config Support** - Use any SSH configuration file with the `-c` flag
+- **🤖 Agent Skill & Headless CLI** - Agent skill for Cursor, Claude Code, and Codex; every operation available from the CLI without the TUI, with JSON output for scripts and agents
 - **📦 Host Import** - Migrate SSH profiles from Tabby with `ctty import --from tabby`
 - **📂 SSH Include Support** - Full support for SSH Include directives to organize configurations across multiple files
 - **⚙️ SSH Options Support** - Add any SSH configuration option through intuitive forms
@@ -479,6 +480,23 @@ ctty sftp prod-server
 
 # Open Serial device manager directly
 ctty serial
+
+# Add/edit a host without opening the form
+ctty add --name web-server --hostname 10.0.1.10 --user root --tags prod
+ctty edit --name web-server --port 2222
+
+# Transfer files over SFTP (no TUI needed)
+ctty put web-server ./app.tar.gz /srv/www/app.tar.gz
+ctty get web-server /var/log/app.log ./app.log
+ctty scp web-server:/etc/ctty.conf ./ctty.conf
+
+# Run the same command on many hosts at once
+ctty exec --tags prod -- uptime
+ctty exec --hosts web-01,db-01 -- df -h
+
+# Query saved devices as JSON (for scripts / agents)
+ctty serial list --format json
+ctty telnet search core --format json
 
 # Override interface language (auto, zh, en)
 ctty --lang zh

--- a/README_CN.md
+++ b/README_CN.md
@@ -47,6 +47,7 @@ ctty 是一个快速、原生的终端工具，用于管理你的所有连接 �
 ### 🛠️ **技术特性**
 - **🔒 安全** - 直接使用现有的 `~/.ssh/config` 文件（密码凭据独立存储，绝不污染标准 SSH 配置）
 - **📁 自定义配置** - 通过 `-c` 标志使用任意 SSH 配置文件
+- **🤖 Agent Skill / 非交互 CLI** - 内置 agent skill（Cursor / Claude Code / Codex）；不开 TUI 也能通过命令行完成全部操作，支持 JSON 输出，方便脚本和 AI 集成
 - **📦 主机导入** - 用 `ctty import --from tabby` 把 Tabby 的 SSH 配置迁过来
 - **📂 SSH Include 支持** - 完整支持 SSH Include 指令，跨多文件组织配置
 - **⚙️ SSH 选项** - 通过直观的表单添加任意 SSH 配置选项
@@ -474,6 +475,23 @@ ctty sftp prod-server
 
 # 直接打开串口设备管理器
 ctty serial
+
+# 不开表单，用参数直接新增/编辑主机
+ctty add --name web-server --hostname 10.0.1.10 --user root --tags prod
+ctty edit --name web-server --port 2222
+
+# 用 SFTP 直接传输文件（无需打开 TUI）
+ctty put web-server ./app.tar.gz /srv/www/app.tar.gz
+ctty get web-server /var/log/app.log ./app.log
+ctty scp web-server:/etc/ctty.conf ./ctty.conf
+
+# 一次在多台主机上执行同一条命令
+ctty exec --tags prod -- uptime
+ctty exec --hosts web-01,db-01 -- df -h
+
+# 用 JSON 查询已保存的串口 / Telnet 设备（方便脚本对接）
+ctty serial list --format json
+ctty telnet search core --format json
 
 # 指定界面语言（auto, zh, en）
 ctty --lang zh

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/zsuroy/ctty/internal/ui"
 
@@ -11,21 +12,42 @@ import (
 var addCmd = &cobra.Command{
 	Use:   "add [hostname]",
 	Short: "Add a new SSH host configuration",
-	Long:  `Add a new SSH host configuration with an interactive form.`,
-	Args:  cobra.MaximumNArgs(1),
+	Long: `Add a new SSH host configuration.
+
+Interactive (default): opens a Bubble Tea form when no host-config flags are set.
+
+Non-interactive: activated when --non-interactive is set, OR when any of
+--name, --hostname, --user, --port, --identity-file, --proxy-jump,
+--proxy-command, --option/-o, --tags, --password, or --force is provided.
+Requires --name (or the positional alias) and --hostname. Reuses the same
+OpenSSH config write/backup/validation path as the TUI form.
+
+Examples:
+  ctty add
+  ctty add myhost
+  ctty add --name web1 --hostname 10.0.0.1 --user deploy --tags prod,web
+  ctty add --name web1 --hostname 10.0.0.1 --force --format json`,
+	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		var hostname string
+		var positional string
 		if len(args) > 0 {
-			hostname = args[0]
+			positional = args[0]
 		}
 
-		err := ui.RunAddForm(hostname, configFile)
+		if wantNonInteractive(cmd) {
+			addHostNonInteractive(cmd, positional)
+			return
+		}
+
+		err := ui.RunAddForm(positional, configFile)
 		if err != nil {
-			fmt.Printf("Error adding host: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error adding host: %v\n", err)
+			os.Exit(1)
 		}
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(addCmd)
+	registerHostCLIFlags(addCmd, true)
 }

--- a/cmd/add_edit_cli_test.go
+++ b/cmd/add_edit_cli_test.go
@@ -1,0 +1,269 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/zsuroy/ctty/internal/config"
+)
+
+func TestAddEditNonInteractiveRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config")
+	if err := os.WriteFile(cfgPath, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Isolate credential/backup dirs
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	origConfig := configFile
+	configFile = cfgPath
+	defer func() { configFile = origConfig }()
+
+	resetHostFlags()
+	t.Cleanup(resetHostFlags)
+
+	addCmd.SetArgs([]string{
+		"--name", "web1",
+		"--hostname", "10.0.0.1",
+		"--user", "deploy",
+		"--port", "2222",
+		"--tags", "prod,web",
+		"--option", "Compression=yes",
+		"--format", "json",
+	})
+	buf := new(bytes.Buffer)
+	addCmd.SetOut(buf)
+	addCmd.SetErr(buf)
+
+	// Execute via Run to avoid root PersistentPreRun side effects issues
+	hostFlagName = "web1"
+	hostFlagHostname = "10.0.0.1"
+	hostFlagUser = "deploy"
+	hostFlagPort = "2222"
+	hostFlagTags = "prod,web"
+	hostFlagOptions = []string{"Compression=yes"}
+	hostFlagFormat = "json"
+	hostFlagForce = false
+	hostFlagNonInteractive = true
+
+	addHostNonInteractive(addCmd, "")
+
+	hosts, err := config.ParseSSHConfigFile(cfgPath)
+	if err != nil {
+		t.Fatalf("parse after add: %v", err)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("expected 1 host, got %d", len(hosts))
+	}
+	h := hosts[0]
+	if h.Name != "web1" || h.Hostname != "10.0.0.1" || h.User != "deploy" || h.Port != "2222" {
+		t.Fatalf("unexpected host after add: %+v", h)
+	}
+	if len(h.Tags) != 2 {
+		t.Fatalf("expected 2 tags, got %v", h.Tags)
+	}
+	if !strings.Contains(h.Options, "Compression") {
+		t.Fatalf("expected Compression option, got %q", h.Options)
+	}
+
+	// Edit: change hostname and port
+	resetHostFlags()
+	t.Cleanup(resetHostFlags)
+	hostFlagHostname = "10.0.0.2"
+	hostFlagPort = "22"
+	hostFlagFormat = "json"
+	hostFlagNonInteractive = true
+	// Mark flags as changed by parsing
+	if err := editCmd.Flags().Set("hostname", "10.0.0.2"); err != nil {
+		t.Fatal(err)
+	}
+	if err := editCmd.Flags().Set("port", "22"); err != nil {
+		t.Fatal(err)
+	}
+	if err := editCmd.Flags().Set("format", "json"); err != nil {
+		t.Fatal(err)
+	}
+	if err := editCmd.Flags().Set("non-interactive", "true"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stdout for JSON
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	editHostNonInteractive(editCmd, "web1")
+	_ = w.Close()
+	os.Stdout = oldStdout
+	var outBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(r)
+
+	hosts, err = config.ParseSSHConfigFile(cfgPath)
+	if err != nil {
+		t.Fatalf("parse after edit: %v", err)
+	}
+	if len(hosts) != 1 {
+		t.Fatalf("expected 1 host after edit, got %d", len(hosts))
+	}
+	h = hosts[0]
+	if h.Hostname != "10.0.0.2" {
+		t.Fatalf("hostname not updated: %s", h.Hostname)
+	}
+	if h.Port != "22" && h.Port != "" {
+		// Port 22 may be omitted from file on write; accept either
+		t.Fatalf("unexpected port: %s", h.Port)
+	}
+
+	var res hostCLIResult
+	if err := json.Unmarshal(outBuf.Bytes(), &res); err != nil {
+		t.Fatalf("json result: %v\nraw: %s", err, outBuf.String())
+	}
+	if !res.OK || res.Action != "updated" {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+}
+
+func TestAddForceOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config")
+	if err := os.WriteFile(cfgPath, []byte(""), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	origConfig := configFile
+	configFile = cfgPath
+	defer func() { configFile = origConfig }()
+
+	resetHostFlags()
+	t.Cleanup(resetHostFlags)
+	hostFlagName = "dup"
+	hostFlagHostname = "1.1.1.1"
+	hostFlagNonInteractive = true
+	hostFlagForce = false
+	addHostNonInteractive(addCmd, "")
+
+	// Second add without force should fail — capture via checking exists path
+	resetHostFlags()
+	t.Cleanup(resetHostFlags)
+	hostFlagName = "dup"
+	hostFlagHostname = "2.2.2.2"
+	hostFlagNonInteractive = true
+	hostFlagForce = false
+	hostFlagFormat = "json"
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	os.Stderr = w
+
+	// writeHostCLIResult calls os.Exit on error — so call underlying pieces
+	exists, err := config.HostExistsInFile("dup", cfgPath)
+	if err != nil || !exists {
+		t.Fatalf("expected host to exist: exists=%v err=%v", exists, err)
+	}
+
+	_ = w.Close()
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	_, _ = r.Read(make([]byte, 1))
+
+	// With force
+	resetHostFlags()
+	t.Cleanup(resetHostFlags)
+	hostFlagName = "dup"
+	hostFlagHostname = "2.2.2.2"
+	hostFlagNonInteractive = true
+	hostFlagForce = true
+	hostFlagFormat = "json"
+
+	r2, w2, _ := os.Pipe()
+	os.Stdout = w2
+	addHostNonInteractive(addCmd, "")
+	_ = w2.Close()
+	os.Stdout = oldStdout
+	var outBuf bytes.Buffer
+	_, _ = outBuf.ReadFrom(r2)
+
+	hosts, err := config.ParseSSHConfigFile(cfgPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, h := range hosts {
+		if h.Name == "dup" && h.Hostname == "2.2.2.2" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("force overwrite failed; hosts=%v out=%s", hosts, outBuf.String())
+	}
+}
+
+func TestWantNonInteractive(t *testing.T) {
+	resetHostFlags()
+	t.Cleanup(resetHostFlags)
+	if wantNonInteractive(addCmd) {
+		t.Fatal("expected interactive by default")
+	}
+	if err := addCmd.Flags().Set("hostname", "x"); err != nil {
+		t.Fatal(err)
+	}
+	if !wantNonInteractive(addCmd) {
+		t.Fatal("expected non-interactive when --hostname set")
+	}
+	_ = addCmd.Flags().Set("hostname", "")
+	// Changed stays true even if emptied — reset by creating fresh check with non-interactive
+	resetHostFlags()
+	t.Cleanup(resetHostFlags)
+	hostFlagNonInteractive = true
+	if !wantNonInteractive(addCmd) {
+		// hostFlagNonInteractive alone should trigger even if flag.Changed is false
+		// wantNonInteractive checks hostFlagNonInteractive first
+	}
+	if !hostFlagNonInteractive {
+		t.Fatal("flag not set")
+	}
+	if !wantNonInteractive(addCmd) {
+		t.Fatal("expected non-interactive when flag var set")
+	}
+}
+
+func resetHostFlags() {
+	hostFlagName = ""
+	hostFlagHostname = ""
+	hostFlagUser = ""
+	hostFlagPort = ""
+	hostFlagIdentityFile = ""
+	hostFlagProxyJump = ""
+	hostFlagProxyCommand = ""
+	hostFlagOptions = nil
+	hostFlagTags = ""
+	hostFlagPassword = ""
+	hostFlagFormat = ""
+	hostFlagForce = false
+	hostFlagNonInteractive = false
+	addCmd.SetArgs(nil)
+	editCmd.SetArgs(nil)
+	addCmd.SetOut(nil)
+	addCmd.SetErr(nil)
+	editCmd.SetOut(nil)
+	editCmd.SetErr(nil)
+	// Reset Changed state on shared flags
+	for _, c := range []*cobra.Command{addCmd, editCmd} {
+		c.Flags().VisitAll(func(f *pflag.Flag) {
+			f.Changed = false
+			_ = f.Value.Set(f.DefValue)
+		})
+	}
+}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/zsuroy/ctty/internal/ui"
 
@@ -11,18 +12,37 @@ import (
 var editCmd = &cobra.Command{
 	Use:   "edit <hostname>",
 	Short: "Edit an existing SSH host configuration",
-	Long:  `Edit an existing SSH host configuration with an interactive form.`,
-	Args:  cobra.ExactArgs(1),
+	Long: `Edit an existing SSH host configuration.
+
+Interactive (default): opens a Bubble Tea form when no host-config flags are set.
+
+Non-interactive: activated when --non-interactive is set, OR when any of
+--name, --hostname, --user, --port, --identity-file, --proxy-jump,
+--proxy-command, --option/-o, --tags, or --password is provided.
+Only changed flags are applied on top of the existing host.
+
+Examples:
+  ctty edit web1
+  ctty edit web1 --hostname 10.0.0.2 --port 2222
+  ctty edit web1 --tags prod,api --format json`,
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		hostname := args[0]
 
+		if wantNonInteractive(cmd) {
+			editHostNonInteractive(cmd, hostname)
+			return
+		}
+
 		err := ui.RunEditForm(hostname, configFile)
 		if err != nil {
-			fmt.Printf("Error editing host: %v\n", err)
+			fmt.Fprintf(os.Stderr, "Error editing host: %v\n", err)
+			os.Exit(1)
 		}
 	},
 }
 
 func init() {
 	RootCmd.AddCommand(editCmd)
+	registerHostCLIFlags(editCmd, false)
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -1,0 +1,265 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/spf13/cobra"
+	"github.com/zsuroy/ctty/internal/config"
+	"github.com/zsuroy/ctty/internal/credential"
+)
+
+var (
+	execTags        string
+	execHosts       string
+	execConcurrency int
+	execFormat      string
+)
+
+type execResult struct {
+	Host     string `json:"host"`
+	OK       bool   `json:"ok"`
+	ExitCode int    `json:"exit_code"`
+	Stdout   string `json:"stdout"`
+	Stderr   string `json:"stderr"`
+	Error    string `json:"error,omitempty"`
+}
+
+var execCmd = &cobra.Command{
+	Use:   "exec [--tags tag1,tag2 | --hosts a,b] -- <command...>",
+	Short: "Run a remote command on multiple SSH hosts",
+	Long: `Execute a remote command on multiple hosts selected by tags and/or host names.
+
+Selection (at least one required):
+  --tags prod,web   hosts that have ANY of the listed tags
+  --hosts a,b,c     explicit Host aliases
+
+Default concurrency is 8 (--concurrency). Human-readable output by default;
+--format json emits an array of {host,ok,exit_code,stdout,stderr}.
+
+Aggregate exit status is 0 if and only if every host succeeded.
+
+Examples:
+  ctty exec --tags prod -- uptime
+  ctty exec --hosts web1,web2 -- df -h
+  ctty exec --tags api --hosts bastion --format json -- systemctl is-active nginx`,
+	Args: cobra.ArbitraryArgs,
+	Run:  runBatchExec,
+}
+
+func runBatchExec(cmd *cobra.Command, args []string) {
+	remoteCmd := args
+	if cmd.ArgsLenAtDash() >= 0 {
+		remoteCmd = args[cmd.ArgsLenAtDash():]
+	}
+	if len(remoteCmd) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: remote command required (use -- before the command)\n")
+		os.Exit(1)
+	}
+
+	tagList := parseTagsCSV(execTags)
+	hostList := splitCSV(execHosts)
+	if len(tagList) == 0 && len(hostList) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: specify --tags and/or --hosts\n")
+		os.Exit(1)
+	}
+
+	hosts, err := loadSSHHosts()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error reading SSH config: %v\n", err)
+		os.Exit(1)
+	}
+
+	selected := selectHosts(hosts, tagList, hostList)
+	if len(selected) == 0 {
+		fmt.Fprintf(os.Stderr, "Error: no hosts matched the selection\n")
+		os.Exit(1)
+	}
+
+	if execConcurrency < 1 {
+		execConcurrency = 8
+	}
+
+	results := runOnHosts(selected, remoteCmd, execConcurrency)
+
+	allOK := true
+	for _, r := range results {
+		if !r.OK {
+			allOK = false
+			break
+		}
+	}
+
+	if execFormat == "json" {
+		b, err := json.MarshalIndent(results, "", "  ")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println(string(b))
+	} else {
+		for _, r := range results {
+			status := "OK"
+			if !r.OK {
+				status = fmt.Sprintf("FAIL (exit %d)", r.ExitCode)
+				if r.Error != "" {
+					status = fmt.Sprintf("FAIL (%s)", r.Error)
+				}
+			}
+			fmt.Printf("=== %s: %s ===\n", r.Host, status)
+			if r.Stdout != "" {
+				fmt.Print(r.Stdout)
+				if !strings.HasSuffix(r.Stdout, "\n") {
+					fmt.Println()
+				}
+			}
+			if r.Stderr != "" {
+				fmt.Fprint(os.Stderr, r.Stderr)
+				if !strings.HasSuffix(r.Stderr, "\n") {
+					fmt.Fprintln(os.Stderr)
+				}
+			}
+		}
+	}
+
+	if !allOK {
+		os.Exit(1)
+	}
+}
+
+func splitCSV(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func loadSSHHosts() ([]config.SSHHost, error) {
+	if configFile != "" {
+		return config.ParseSSHConfigFile(configFile)
+	}
+	return config.ParseSSHConfig()
+}
+
+func selectHosts(hosts []config.SSHHost, tags, names []string) []config.SSHHost {
+	nameSet := make(map[string]bool, len(names))
+	for _, n := range names {
+		nameSet[n] = true
+	}
+
+	var selected []config.SSHHost
+	seen := make(map[string]bool)
+
+	for _, h := range hosts {
+		match := false
+		if len(names) > 0 && nameSet[h.Name] {
+			match = true
+		}
+		if len(tags) > 0 && config.HostHasAnyTag(h.Tags, tags) {
+			match = true
+		}
+		// If only tags were given, names empty — tag match is enough.
+		// If only names — name match.
+		// If both — OR semantics (either).
+		if !match {
+			continue
+		}
+		if seen[h.Name] {
+			continue
+		}
+		seen[h.Name] = true
+		selected = append(selected, h)
+	}
+	return selected
+}
+
+func runOnHosts(hosts []config.SSHHost, remoteCmd []string, concurrency int) []execResult {
+	results := make([]execResult, len(hosts))
+	sem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for i, h := range hosts {
+		wg.Add(1)
+		go func(i int, host config.SSHHost) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			results[i] = runSSHCommand(host.Name, remoteCmd)
+		}(i, h)
+	}
+	wg.Wait()
+	return results
+}
+
+// runSSHCommand runs a remote command via the system ssh client (same path as
+// ctty <host> <cmd>), capturing stdout/stderr instead of replacing the process.
+func runSSHCommand(hostName string, remoteCmd []string) execResult {
+	res := execResult{Host: hostName, ExitCode: 1}
+
+	var args []string
+	if configFile != "" {
+		args = append(args, "-F", configFile)
+	}
+	args = append(args, hostName)
+	args = append(args, remoteCmd...)
+
+	sshCmd := exec.Command("ssh", args...)
+	env := os.Environ()
+	if pass, ok := credential.GetPassword(hostName); ok && pass != "" {
+		selfPath, err := os.Executable()
+		if err == nil {
+			env = append(env,
+				"SSH_ASKPASS="+selfPath,
+				"SSH_ASKPASS_REQUIRE=force",
+				"CTTY_ASKPASS_TOKEN="+base64.StdEncoding.EncodeToString([]byte(pass)),
+				"DISPLAY=ctty:0",
+			)
+		}
+	}
+	sshCmd.Env = env
+
+	var stdout, stderr bytes.Buffer
+	sshCmd.Stdout = &stdout
+	sshCmd.Stderr = &stderr
+
+	err := sshCmd.Run()
+	res.Stdout = stdout.String()
+	res.Stderr = stderr.String()
+
+	if err == nil {
+		res.OK = true
+		res.ExitCode = 0
+		return res
+	}
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			res.ExitCode = status.ExitStatus()
+		}
+		return res
+	}
+	res.Error = err.Error()
+	return res
+}
+
+func init() {
+	RootCmd.AddCommand(execCmd)
+	execCmd.Flags().StringVar(&execTags, "tags", "", "Comma-separated tags; hosts matching ANY tag are selected")
+	execCmd.Flags().StringVar(&execHosts, "hosts", "", "Comma-separated Host aliases")
+	execCmd.Flags().IntVar(&execConcurrency, "concurrency", 8, "Max parallel SSH sessions")
+	execCmd.Flags().StringVar(&execFormat, "format", "", "Output format: json for machine-readable array")
+}

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/zsuroy/ctty/internal/config"
+)
+
+func TestSelectHosts(t *testing.T) {
+	hosts := []config.SSHHost{
+		{Name: "a", Tags: []string{"prod", "web"}},
+		{Name: "b", Tags: []string{"dev"}},
+		{Name: "c", Tags: []string{"prod", "api"}},
+		{Name: "d", Tags: nil},
+	}
+
+	got := selectHosts(hosts, []string{"prod"}, nil)
+	if len(got) != 2 {
+		t.Fatalf("tags prod: want 2, got %d", len(got))
+	}
+
+	got = selectHosts(hosts, nil, []string{"b", "d"})
+	if len(got) != 2 {
+		t.Fatalf("hosts b,d: want 2, got %d", len(got))
+	}
+
+	got = selectHosts(hosts, []string{"prod"}, []string{"b"})
+	if len(got) != 3 {
+		t.Fatalf("tags OR hosts: want 3, got %d (%v)", len(got), namesOf(got))
+	}
+
+	got = selectHosts(hosts, []string{"missing"}, nil)
+	if len(got) != 0 {
+		t.Fatalf("expected empty")
+	}
+}
+
+func namesOf(hosts []config.SSHHost) []string {
+	var n []string
+	for _, h := range hosts {
+		n = append(n, h.Name)
+	}
+	return n
+}
+
+func TestSplitCSV(t *testing.T) {
+	got := splitCSV(" a, b ,c")
+	if len(got) != 3 || got[0] != "a" || got[2] != "c" {
+		t.Fatalf("got %v", got)
+	}
+}

--- a/cmd/host_cli.go
+++ b/cmd/host_cli.go
@@ -1,0 +1,326 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zsuroy/ctty/internal/config"
+	"github.com/zsuroy/ctty/internal/credential"
+	"github.com/zsuroy/ctty/internal/validation"
+)
+
+// Shared non-interactive host flags (bound in add/edit init).
+var (
+	hostFlagName           string
+	hostFlagHostname       string
+	hostFlagUser           string
+	hostFlagPort           string
+	hostFlagIdentityFile   string
+	hostFlagProxyJump      string
+	hostFlagProxyCommand   string
+	hostFlagOptions        []string
+	hostFlagTags           string
+	hostFlagPassword       string
+	hostFlagFormat         string
+	hostFlagForce          bool
+	hostFlagNonInteractive bool
+)
+
+// hostMutatingFlagNames are flags that trigger non-interactive mode when set.
+var hostMutatingFlagNames = []string{
+	"name", "hostname", "user", "port", "identity-file",
+	"proxy-jump", "proxy-command", "option", "tags", "password",
+	"force", "non-interactive",
+}
+
+// wantNonInteractive reports whether add/edit should skip the TUI.
+// Trigger: --non-interactive is set, OR any host-config flag was explicitly
+// provided on the command line (e.g. --hostname, --name, --user, ...).
+func wantNonInteractive(cmd *cobra.Command) bool {
+	if hostFlagNonInteractive {
+		return true
+	}
+	for _, name := range hostMutatingFlagNames {
+		if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+			return true
+		}
+	}
+	return false
+}
+
+func registerHostCLIFlags(cmd *cobra.Command, includeForce bool) {
+	cmd.Flags().StringVar(&hostFlagName, "name", "", "Host alias (required in non-interactive mode)")
+	cmd.Flags().StringVar(&hostFlagHostname, "hostname", "", "Remote hostname or IP")
+	cmd.Flags().StringVar(&hostFlagUser, "user", "", "SSH username")
+	cmd.Flags().StringVar(&hostFlagPort, "port", "", "SSH port (default 22)")
+	cmd.Flags().StringVar(&hostFlagIdentityFile, "identity-file", "", "Path to identity (private key) file")
+	cmd.Flags().StringVar(&hostFlagProxyJump, "proxy-jump", "", "ProxyJump bastion host")
+	cmd.Flags().StringVar(&hostFlagProxyCommand, "proxy-command", "", "ProxyCommand")
+	cmd.Flags().StringArrayVarP(&hostFlagOptions, "option", "o", nil, "SSH config option (repeatable), e.g. Compression=yes")
+	cmd.Flags().StringVar(&hostFlagTags, "tags", "", "Comma-separated tags")
+	cmd.Flags().StringVar(&hostFlagPassword, "password", "", "Optional password stored in credential vault only (never written to SSH config, never printed)")
+	cmd.Flags().StringVar(&hostFlagFormat, "format", "", "Output format: json for agent-friendly success payload")
+	cmd.Flags().BoolVar(&hostFlagNonInteractive, "non-interactive", false, "Force non-interactive mode (skip TUI form)")
+	if includeForce {
+		cmd.Flags().BoolVar(&hostFlagForce, "force", false, "Overwrite an existing host with the same name")
+	}
+}
+
+func parseTagsCSV(s string) []string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	var tags []string
+	for _, tag := range strings.Split(s, ",") {
+		tag = strings.TrimSpace(tag)
+		tag = strings.TrimPrefix(tag, "#")
+		if tag != "" {
+			tags = append(tags, tag)
+		}
+	}
+	return tags
+}
+
+func optionsFromFlags(opts []string) string {
+	if len(opts) == 0 {
+		return ""
+	}
+	// Join as repeated -o forms so ParseSSHOptionsFromCommand handles them.
+	var parts []string
+	for _, o := range opts {
+		o = strings.TrimSpace(o)
+		if o == "" {
+			continue
+		}
+		if strings.HasPrefix(o, "-o") {
+			parts = append(parts, o)
+		} else {
+			parts = append(parts, "-o "+o)
+		}
+	}
+	return config.ParseSSHOptionsFromCommand(strings.Join(parts, " "))
+}
+
+func resolveConfigPath() (string, error) {
+	if configFile != "" {
+		return configFile, nil
+	}
+	return config.GetDefaultSSHConfigPath()
+}
+
+func loadHostByName(name, cfgPath string) (*config.SSHHost, error) {
+	var hosts []config.SSHHost
+	var err error
+	if cfgPath != "" {
+		hosts, err = config.ParseSSHConfigFile(cfgPath)
+	} else {
+		hosts, err = config.ParseSSHConfig()
+	}
+	if err != nil {
+		return nil, err
+	}
+	for i := range hosts {
+		if hosts[i].Name == name {
+			return &hosts[i], nil
+		}
+	}
+	return nil, fmt.Errorf("host %q not found", name)
+}
+
+type hostCLIResult struct {
+	OK       bool     `json:"ok"`
+	Action   string   `json:"action"`
+	Name     string   `json:"name"`
+	Hostname string   `json:"hostname"`
+	User     string   `json:"user,omitempty"`
+	Port     string   `json:"port,omitempty"`
+	Tags     []string `json:"tags,omitempty"`
+	Error    string   `json:"error,omitempty"`
+}
+
+func writeHostCLIResult(action string, host config.SSHHost, err error) {
+	res := hostCLIResult{
+		OK:       err == nil,
+		Action:   action,
+		Name:     host.Name,
+		Hostname: host.Hostname,
+		User:     host.User,
+		Port:     host.Port,
+		Tags:     host.Tags,
+	}
+	if err != nil {
+		res.Error = err.Error()
+	}
+	if hostFlagFormat == "json" {
+		b, mErr := json.Marshal(res)
+		if mErr != nil {
+			fmt.Fprintf(os.Stderr, "Error marshaling JSON: %v\n", mErr)
+			os.Exit(1)
+		}
+		fmt.Println(string(b))
+		if err != nil {
+			os.Exit(1)
+		}
+		return
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("Host %q %s successfully.\n", host.Name, action)
+}
+
+func storePasswordIfSet(hostName, password string) error {
+	if password == "" {
+		return nil
+	}
+	return credential.SetPassword(hostName, password)
+}
+
+func addHostNonInteractive(cmd *cobra.Command, positionalName string) {
+	name := strings.TrimSpace(hostFlagName)
+	if name == "" {
+		name = strings.TrimSpace(positionalName)
+	}
+	hostname := strings.TrimSpace(hostFlagHostname)
+
+	if name == "" || hostname == "" {
+		fmt.Fprintf(os.Stderr, "Error: non-interactive add requires --name and --hostname (or pass the alias as the argument with --hostname).\n")
+		fmt.Fprintf(os.Stderr, "Trigger: --non-interactive or any of --name/--hostname/--user/--port/--identity-file/--proxy-jump/--proxy-command/--option/--tags/--password/--force.\n")
+		os.Exit(1)
+	}
+
+	port := strings.TrimSpace(hostFlagPort)
+	if port == "" {
+		port = "22"
+	}
+	user := strings.TrimSpace(hostFlagUser)
+	identity := strings.TrimSpace(hostFlagIdentityFile)
+
+	if err := validation.ValidateHost(name, hostname, port, identity); err != nil {
+		writeHostCLIResult("added", config.SSHHost{Name: name, Hostname: hostname}, err)
+		return
+	}
+
+	host := config.SSHHost{
+		Name:         name,
+		Hostname:     hostname,
+		User:         user,
+		Port:         port,
+		Identity:     identity,
+		ProxyJump:    strings.TrimSpace(hostFlagProxyJump),
+		ProxyCommand: strings.TrimSpace(hostFlagProxyCommand),
+		Options:      optionsFromFlags(hostFlagOptions),
+		Tags:         parseTagsCSV(hostFlagTags),
+	}
+
+	cfgPath, err := resolveConfigPath()
+	if err != nil {
+		writeHostCLIResult("added", host, err)
+		return
+	}
+
+	exists, err := config.HostExistsInFile(name, cfgPath)
+	if err != nil {
+		writeHostCLIResult("added", host, err)
+		return
+	}
+
+	action := "added"
+	if exists {
+		if !hostFlagForce {
+			writeHostCLIResult("added", host, fmt.Errorf("host %q already exists (use --force to overwrite)", name))
+			return
+		}
+		action = "updated"
+		err = config.UpdateSSHHostInFile(name, host, cfgPath)
+	} else {
+		err = config.AddSSHHostToFile(host, cfgPath)
+	}
+	if err != nil {
+		writeHostCLIResult(action, host, err)
+		return
+	}
+
+	if err := storePasswordIfSet(name, hostFlagPassword); err != nil {
+		writeHostCLIResult(action, host, fmt.Errorf("host saved but failed to store password: %w", err))
+		return
+	}
+
+	writeHostCLIResult(action, host, nil)
+}
+
+func editHostNonInteractive(cmd *cobra.Command, targetName string) {
+	cfgPath, err := resolveConfigPath()
+	if err != nil {
+		writeHostCLIResult("updated", config.SSHHost{Name: targetName}, err)
+		return
+	}
+
+	existing, err := loadHostByName(targetName, cfgPath)
+	if err != nil {
+		writeHostCLIResult("updated", config.SSHHost{Name: targetName}, err)
+		return
+	}
+
+	host := *existing
+
+	if cmd.Flags().Changed("name") && strings.TrimSpace(hostFlagName) != "" {
+		host.Name = strings.TrimSpace(hostFlagName)
+	}
+	if cmd.Flags().Changed("hostname") {
+		host.Hostname = strings.TrimSpace(hostFlagHostname)
+	}
+	if cmd.Flags().Changed("user") {
+		host.User = strings.TrimSpace(hostFlagUser)
+	}
+	if cmd.Flags().Changed("port") {
+		host.Port = strings.TrimSpace(hostFlagPort)
+		if host.Port == "" {
+			host.Port = "22"
+		}
+	}
+	if cmd.Flags().Changed("identity-file") {
+		host.Identity = strings.TrimSpace(hostFlagIdentityFile)
+	}
+	if cmd.Flags().Changed("proxy-jump") {
+		host.ProxyJump = strings.TrimSpace(hostFlagProxyJump)
+	}
+	if cmd.Flags().Changed("proxy-command") {
+		host.ProxyCommand = strings.TrimSpace(hostFlagProxyCommand)
+	}
+	if cmd.Flags().Changed("option") {
+		host.Options = optionsFromFlags(hostFlagOptions)
+	}
+	if cmd.Flags().Changed("tags") {
+		host.Tags = parseTagsCSV(hostFlagTags)
+	}
+
+	if err := validation.ValidateHost(host.Name, host.Hostname, host.Port, host.Identity); err != nil {
+		writeHostCLIResult("updated", host, err)
+		return
+	}
+
+	sourceFile := existing.SourceFile
+	if sourceFile == "" {
+		sourceFile = cfgPath
+	}
+
+	if err := config.UpdateSSHHostInFile(targetName, host, sourceFile); err != nil {
+		writeHostCLIResult("updated", host, err)
+		return
+	}
+
+	if cmd.Flags().Changed("password") {
+		if err := storePasswordIfSet(host.Name, hostFlagPassword); err != nil {
+			writeHostCLIResult("updated", host, fmt.Errorf("host updated but failed to store password: %w", err))
+			return
+		}
+	}
+
+	writeHostCLIResult("updated", host, nil)
+}

--- a/cmd/serial.go
+++ b/cmd/serial.go
@@ -1,30 +1,193 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
+	"os"
+	"strings"
 
+	"github.com/zsuroy/ctty/internal/serialconfig"
 	"github.com/zsuroy/ctty/internal/ui"
 
 	"github.com/spf13/cobra"
 )
 
-// serialCmd represents the serial command
-var serialCmd = &cobra.Command{
-	Use:   "serial",
-	Short: "Open serial device manager",
-	Long: `Open the serial device manager TUI directly.
+var serialFormat string
 
-Lists auto-detected serial ports and saved device configurations.
-Press Enter to connect, e to edit parameters, a to add, d to delete.`,
-	Run: func(cmd *cobra.Command, args []string) {
-		if err := ui.RunSerialMode(AppVersion, noUpdateCheck); err != nil {
-			log.Fatalf("Error running serial mode: %v", err)
+// serialCmd represents the serial command.
+// No-args opens the TUI. Subcommands list|search|info support --format json
+// for agents without breaking shell completions for the parent.
+var serialCmd = &cobra.Command{
+	Use:   "serial [list|search|info]",
+	Short: "Open serial device manager or query saved devices",
+	Long: `Open the serial device manager TUI, or query saved devices non-interactively.
+
+Forms:
+  ctty serial                         Open TUI device manager
+  ctty serial list [--format json]    List saved devices
+  ctty serial search [query] [--format json]
+  ctty serial info <name> [--format json]
+
+Auto-detected ports appear in the TUI only; CLI list/search/info read
+~/.config/ctty/serial.json.`,
+	Args: cobra.ArbitraryArgs,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) >= 1 {
+			if args[0] == "info" && len(args) == 1 {
+				return completeSerialNames(toComplete), cobra.ShellCompDirectiveNoFileComp
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		fmt.Println()
+		base := []string{"list", "search", "info"}
+		names := completeSerialNames(toComplete)
+		var out []string
+		lower := strings.ToLower(toComplete)
+		for _, b := range base {
+			if strings.HasPrefix(b, lower) {
+				out = append(out, b)
+			}
+		}
+		out = append(out, names...)
+		return out, cobra.ShellCompDirectiveNoFileComp
 	},
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			if err := ui.RunSerialMode(AppVersion, noUpdateCheck); err != nil {
+				log.Fatalf("Error running serial mode: %v", err)
+			}
+			fmt.Println()
+			return
+		}
+
+		switch args[0] {
+		case "list":
+			runSerialList()
+		case "search":
+			q := ""
+			if len(args) > 1 {
+				q = strings.Join(args[1:], " ")
+			}
+			runSerialSearch(q)
+		case "info":
+			if len(args) < 2 {
+				fmt.Fprintf(os.Stderr, "Error: serial info requires a device name\n")
+				os.Exit(1)
+			}
+			runSerialInfo(args[1])
+		default:
+			fmt.Fprintf(os.Stderr, "Error: unknown serial subcommand %q (use list, search, info, or no args for TUI)\n", args[0])
+			os.Exit(1)
+		}
+	},
+}
+
+func completeSerialNames(toComplete string) []string {
+	devices, err := serialconfig.Load()
+	if err != nil {
+		return nil
+	}
+	lower := strings.ToLower(toComplete)
+	var out []string
+	for _, d := range devices {
+		if strings.HasPrefix(strings.ToLower(d.Name), lower) {
+			out = append(out, d.Name)
+		}
+	}
+	return out
+}
+
+func runSerialList() {
+	devices, err := serialconfig.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	outputSerialDevices(devices)
+}
+
+func runSerialSearch(query string) {
+	devices, err := serialconfig.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		outputSerialDevices(devices)
+		return
+	}
+	words := strings.Fields(strings.ToLower(query))
+	var matched []serialconfig.SerialDevice
+	for _, d := range devices {
+		hay := strings.ToLower(d.Name + " " + d.Device)
+		ok := true
+		for _, w := range words {
+			if !strings.Contains(hay, w) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			matched = append(matched, d)
+		}
+	}
+	outputSerialDevices(matched)
+}
+
+func runSerialInfo(name string) {
+	dev, ok := serialconfig.Find(name)
+	if !ok {
+		if serialFormat == "json" {
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+				"ok": false, "error": "NOT_FOUND", "name": name,
+			})
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: serial device %q not found\n", name)
+		}
+		os.Exit(2)
+	}
+	if serialFormat == "json" {
+		_ = json.NewEncoder(os.Stdout).Encode(dev)
+		return
+	}
+	fmt.Printf("Name:         %s\n", dev.Name)
+	fmt.Printf("Device:       %s\n", dev.Device)
+	fmt.Printf("Baud Rate:    %d\n", dev.BaudRate)
+	fmt.Printf("Data Bits:    %d\n", dev.DataBits)
+	fmt.Printf("Parity:       %s\n", dev.Parity)
+	fmt.Printf("Stop Bits:    %d\n", dev.StopBits)
+	fmt.Printf("Flow Control: %s\n", dev.FlowControl)
+}
+
+func outputSerialDevices(devices []serialconfig.SerialDevice) {
+	if serialFormat == "json" {
+		if devices == nil {
+			devices = []serialconfig.SerialDevice{}
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(devices)
+		return
+	}
+	if len(devices) == 0 {
+		fmt.Println("No serial devices found.")
+		return
+	}
+	for _, d := range devices {
+		fmt.Printf("%-20s %s  %d %d%s%d %s\n",
+			d.Name, d.Device, d.BaudRate, d.DataBits, parityShort(d.Parity), d.StopBits, d.FlowControl)
+	}
+}
+
+func parityShort(p string) string {
+	if p == "" {
+		return "?"
+	}
+	return p[:1]
 }
 
 func init() {
 	RootCmd.AddCommand(serialCmd)
+	serialCmd.Flags().StringVar(&serialFormat, "format", "", "Output format: json")
 }

--- a/cmd/serial_telnet_cli_test.go
+++ b/cmd/serial_telnet_cli_test.go
@@ -1,0 +1,110 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/zsuroy/ctty/internal/serialconfig"
+	"github.com/zsuroy/ctty/internal/telnetconfig"
+)
+
+func TestSerialListJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	dev := serialconfig.DefaultDevice()
+	dev.Name = "console1"
+	dev.Device = "/dev/ttyUSB0"
+	if err := serialconfig.Add(dev); err != nil {
+		t.Fatal(err)
+	}
+
+	serialFormat = "json"
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	runSerialList()
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	var devices []serialconfig.SerialDevice
+	if err := json.Unmarshal(buf.Bytes(), &devices); err != nil {
+		t.Fatalf("json: %v\n%s", err, buf.String())
+	}
+	if len(devices) != 1 || devices[0].Name != "console1" {
+		t.Fatalf("unexpected: %v", devices)
+	}
+
+	serialFormat = "json"
+	r2, w2, _ := os.Pipe()
+	os.Stdout = w2
+	runSerialInfo("console1")
+	_ = w2.Close()
+	os.Stdout = old
+	buf.Reset()
+	_, _ = io.Copy(&buf, r2)
+	var one serialconfig.SerialDevice
+	if err := json.Unmarshal(buf.Bytes(), &one); err != nil {
+		t.Fatal(err)
+	}
+	if one.Device != "/dev/ttyUSB0" {
+		t.Fatalf("info: %+v", one)
+	}
+
+}
+
+func TestTelnetListSearchJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	if err := telnetconfig.Add(telnetconfig.TelnetHost{
+		Name: "core-sw", Host: "192.168.1.1", Port: 23, Tags: []string{"lab"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := telnetconfig.Add(telnetconfig.TelnetHost{
+		Name: "edge", Host: "10.0.0.5", Port: 2001,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	telnetFormat = "json"
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	runTelnetList()
+	_ = w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+
+	var hosts []telnetconfig.TelnetHost
+	if err := json.Unmarshal(buf.Bytes(), &hosts); err != nil {
+		t.Fatalf("json: %v\n%s", err, buf.String())
+	}
+	if len(hosts) != 2 {
+		t.Fatalf("want 2 hosts, got %d", len(hosts))
+	}
+
+	r2, w2, _ := os.Pipe()
+	os.Stdout = w2
+	runTelnetSearch("lab")
+	_ = w2.Close()
+	os.Stdout = old
+	buf.Reset()
+	_, _ = io.Copy(&buf, r2)
+	hosts = nil
+	if err := json.Unmarshal(buf.Bytes(), &hosts); err != nil {
+		t.Fatal(err)
+	}
+	if len(hosts) != 1 || hosts[0].Name != "core-sw" {
+		t.Fatalf("search: %v", hosts)
+	}
+}

--- a/cmd/telnet.go
+++ b/cmd/telnet.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net"
+	"os"
 	"strconv"
 	"strings"
 
@@ -14,45 +16,53 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// telnetCmd opens the telnet device manager or connects directly.
+var telnetFormat string
+
+// telnetCmd opens the telnet device manager, queries saved devices, or connects.
 //
 // Forms:
 //
-//	ctty telnet                 → saved-device manager TUI
-//	ctty telnet <name>          → connect to a saved device by name
-//	ctty telnet <host[:port]>   → one-off direct connection
+//	ctty telnet                         → saved-device manager TUI
+//	ctty telnet list|search|info …      → non-interactive JSON/human query
+//	ctty telnet <name>                  → connect to a saved device by name
+//	ctty telnet <host[:port]>           → one-off direct connection
 var telnetCmd = &cobra.Command{
-	Use:   "telnet [host|name]",
-	Short: "Open telnet device manager or connect to a telnet host",
-	Long: `Open the telnet device manager TUI directly, or connect to a telnet endpoint.
+	Use:   "telnet [list|search|info|host|name]",
+	Short: "Open telnet device manager, query devices, or connect",
+	Long: `Open the telnet device manager TUI, query saved devices, or connect.
 
 Telnet targets are lab equipment, console servers, and legacy network gear.
 Traffic (including passwords) is transmitted in cleartext — use SSH where possible.
 
 Forms:
-  ctty telnet                  List and manage saved telnet devices
-  ctty telnet core-sw          Connect to a saved device by name
-  ctty telnet 192.168.1.1      Connect to host on port 23
-  ctty telnet 10.0.0.5:2001    Connect with an explicit port
+  ctty telnet                          List and manage saved telnet devices (TUI)
+  ctty telnet list [--format json]     List saved devices
+  ctty telnet search [query] [--format json]
+  ctty telnet info <name> [--format json]
+  ctty telnet core-sw                  Connect to a saved device by name
+  ctty telnet 192.168.1.1              Connect to host on port 23
+  ctty telnet 10.0.0.5:2001            Connect with an explicit port
 
 Press Ctrl-] during a session to disconnect.`,
-	Args: cobra.MaximumNArgs(1),
+	Args: cobra.ArbitraryArgs,
 	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
+		if len(args) >= 1 {
+			if args[0] == "info" && len(args) == 1 {
+				return completeTelnetNames(toComplete), cobra.ShellCompDirectiveNoFileComp
+			}
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
-		hosts, err := telnetconfig.Load()
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-		completions := make([]string, 0, len(hosts))
-		toCompleteLower := strings.ToLower(toComplete)
-		for _, h := range hosts {
-			if strings.HasPrefix(strings.ToLower(h.Name), toCompleteLower) {
-				completions = append(completions, h.Name)
+		base := []string{"list", "search", "info"}
+		names := completeTelnetNames(toComplete)
+		var out []string
+		lower := strings.ToLower(toComplete)
+		for _, b := range base {
+			if strings.HasPrefix(b, lower) {
+				out = append(out, b)
 			}
 		}
-		return completions, cobra.ShellCompDirectiveNoFileComp
+		out = append(out, names...)
+		return out, cobra.ShellCompDirectiveNoFileComp
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if len(args) == 0 {
@@ -60,6 +70,26 @@ Press Ctrl-] during a session to disconnect.`,
 				log.Fatalf("Error running telnet mode: %v", err)
 			}
 			fmt.Println()
+			return
+		}
+
+		switch args[0] {
+		case "list":
+			runTelnetList()
+			return
+		case "search":
+			q := ""
+			if len(args) > 1 {
+				q = strings.Join(args[1:], " ")
+			}
+			runTelnetSearch(q)
+			return
+		case "info":
+			if len(args) < 2 {
+				fmt.Fprintf(os.Stderr, "Error: telnet info requires a device name\n")
+				os.Exit(1)
+			}
+			runTelnetInfo(args[1])
 			return
 		}
 
@@ -76,6 +106,107 @@ Press Ctrl-] during a session to disconnect.`,
 		}
 		connectTelnet(host, port)
 	},
+}
+
+func completeTelnetNames(toComplete string) []string {
+	hosts, err := telnetconfig.Load()
+	if err != nil {
+		return nil
+	}
+	lower := strings.ToLower(toComplete)
+	var out []string
+	for _, h := range hosts {
+		if strings.HasPrefix(strings.ToLower(h.Name), lower) {
+			out = append(out, h.Name)
+		}
+	}
+	return out
+}
+
+func runTelnetList() {
+	hosts, err := telnetconfig.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	outputTelnetHosts(hosts)
+}
+
+func runTelnetSearch(query string) {
+	hosts, err := telnetconfig.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	query = strings.TrimSpace(query)
+	if query == "" {
+		outputTelnetHosts(hosts)
+		return
+	}
+	words := strings.Fields(strings.ToLower(query))
+	var matched []telnetconfig.TelnetHost
+	for _, h := range hosts {
+		hay := strings.ToLower(h.Name + " " + h.Host + " " + strings.Join(h.Tags, " "))
+		ok := true
+		for _, w := range words {
+			w = strings.TrimPrefix(w, "#")
+			if !strings.Contains(hay, w) {
+				ok = false
+				break
+			}
+		}
+		if ok {
+			matched = append(matched, h)
+		}
+	}
+	outputTelnetHosts(matched)
+}
+
+func runTelnetInfo(name string) {
+	dev, ok := telnetconfig.Find(name)
+	if !ok {
+		if telnetFormat == "json" {
+			_ = json.NewEncoder(os.Stdout).Encode(map[string]interface{}{
+				"ok": false, "error": "NOT_FOUND", "name": name,
+			})
+		} else {
+			fmt.Fprintf(os.Stderr, "Error: telnet host %q not found\n", name)
+		}
+		os.Exit(2)
+	}
+	if telnetFormat == "json" {
+		_ = json.NewEncoder(os.Stdout).Encode(dev)
+		return
+	}
+	fmt.Printf("Name: %s\n", dev.Name)
+	fmt.Printf("Host: %s\n", dev.Host)
+	fmt.Printf("Port: %d\n", dev.Port)
+	if len(dev.Tags) > 0 {
+		fmt.Printf("Tags: %s\n", strings.Join(dev.Tags, ", "))
+	}
+}
+
+func outputTelnetHosts(hosts []telnetconfig.TelnetHost) {
+	if telnetFormat == "json" {
+		if hosts == nil {
+			hosts = []telnetconfig.TelnetHost{}
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(hosts)
+		return
+	}
+	if len(hosts) == 0 {
+		fmt.Println("No telnet hosts found.")
+		return
+	}
+	for _, h := range hosts {
+		tags := ""
+		if len(h.Tags) > 0 {
+			tags = " [" + strings.Join(h.Tags, ", ") + "]"
+		}
+		fmt.Printf("%-20s %s:%d%s\n", h.Name, h.Host, h.Port, tags)
+	}
 }
 
 // connectTelnet dials and runs the interactive bridge until disconnect.
@@ -95,4 +226,5 @@ func connectTelnet(host string, port int) {
 
 func init() {
 	RootCmd.AddCommand(telnetCmd)
+	telnetCmd.Flags().StringVar(&telnetFormat, "format", "", "Output format: json (for list/search/info)")
 }

--- a/cmd/transfer.go
+++ b/cmd/transfer.go
@@ -1,0 +1,211 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/zsuroy/ctty/internal/sftpconfig"
+)
+
+// ParseTransferTarget splits an scp-style "host:path" token.
+// Returns host, remotePath, true when the token looks like host:path
+// (host has no slash; path may be empty → ".").
+func ParseTransferTarget(token string) (host, remotePath string, ok bool) {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", "", false
+	}
+	// Windows drive letters: C:\... is local, not host:path
+	if len(token) >= 2 && token[1] == ':' && ((token[0] >= 'A' && token[0] <= 'Z') || (token[0] >= 'a' && token[0] <= 'z')) {
+		if len(token) == 2 || token[2] == '/' || token[2] == '\\' {
+			return "", "", false
+		}
+	}
+	idx := strings.Index(token, ":")
+	if idx <= 0 {
+		return "", "", false
+	}
+	host = token[:idx]
+	remotePath = token[idx+1:]
+	if strings.Contains(host, "/") || strings.Contains(host, `\`) {
+		return "", "", false
+	}
+	if remotePath == "" {
+		remotePath = "."
+	}
+	return host, remotePath, true
+}
+
+func progressPrinter(label string) func(transferred, total int64) {
+	return func(transferred, total int64) {
+		if total <= 0 {
+			fmt.Fprintf(os.Stderr, "\r%s %d bytes", label, transferred)
+			return
+		}
+		pct := float64(transferred) * 100 / float64(total)
+		fmt.Fprintf(os.Stderr, "\r%s %d/%d (%.0f%%)", label, transferred, total, pct)
+	}
+}
+
+func finishProgress() {
+	fmt.Fprintln(os.Stderr)
+}
+
+func connectTransferClient(hostName string) (*sftpconfig.SFTPClient, error) {
+	client, err := sftpconfig.ConnectWithPassword(hostName, configFile, "")
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+var putCmd = &cobra.Command{
+	Use:   "put <host> <local> <remote>",
+	Short: "Upload a local file or directory to a remote host via SFTP",
+	Long: `Upload a local file or directory to a remote host using the built-in SFTP client.
+
+Progress is written to stderr. Directories are transferred recursively.
+Exit status is non-zero on failure.
+
+Example:
+  ctty put web1 ./deploy.sh /tmp/deploy.sh
+  ctty put web1 ./out/ /opt/app/`,
+	Args:              cobra.ExactArgs(3),
+	ValidArgsFunction: hostCompletionFirstArg,
+	Run: func(cmd *cobra.Command, args []string) {
+		runPut(args[0], args[1], args[2])
+	},
+}
+
+var getCmd = &cobra.Command{
+	Use:   "get <host> <remote> <local>",
+	Short: "Download a remote file or directory via SFTP",
+	Long: `Download a remote file or directory using the built-in SFTP client.
+
+Progress is written to stderr. Directories are transferred recursively.
+Exit status is non-zero on failure.
+
+Example:
+  ctty get web1 /var/log/app.log ./app.log
+  ctty get web1 /opt/app/ ./app-backup/`,
+	Args:              cobra.ExactArgs(3),
+	ValidArgsFunction: hostCompletionFirstArg,
+	Run: func(cmd *cobra.Command, args []string) {
+		runGet(args[0], args[1], args[2])
+	},
+}
+
+var scpCmd = &cobra.Command{
+	Use:   "scp <src> <dst>",
+	Short: "SCP-style file transfer (host:path ↔ local)",
+	Long: `Transfer files using scp-like host:path notation via the built-in SFTP client.
+
+Forms:
+  ctty scp ./local web1:/remote     # upload (put)
+  ctty scp web1:/remote ./local     # download (get)
+
+Progress on stderr; non-zero exit on failure. Directories are recursive.`,
+	Args: cobra.ExactArgs(2),
+	Run: func(cmd *cobra.Command, args []string) {
+		runSCP(args[0], args[1])
+	},
+}
+
+func hostCompletionFirstArg(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveDefault
+	}
+	return RootCmd.ValidArgsFunction(cmd, args, toComplete)
+}
+
+func runPut(hostName, localPath, remotePath string) {
+	client, err := connectTransferClient(hostName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Close()
+
+	info, err := os.Stat(localPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// If remote ends with / or local is a dir without explicit remote file name, join basename.
+	if info.IsDir() {
+		remotePath = strings.TrimRight(remotePath, "/")
+	} else if strings.HasSuffix(remotePath, "/") {
+		remotePath = path.Join(remotePath, filepath.Base(localPath))
+	}
+
+	label := fmt.Sprintf("put %s → %s:%s", localPath, hostName, remotePath)
+	progress := progressPrinter(label)
+	if err := client.UploadPath(context.Background(), localPath, remotePath, progress); err != nil {
+		finishProgress()
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	finishProgress()
+	fmt.Printf("Uploaded %s to %s:%s\n", localPath, hostName, remotePath)
+}
+
+func runGet(hostName, remotePath, localPath string) {
+	client, err := connectTransferClient(hostName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	defer client.Close()
+
+	info, err := client.Stat(remotePath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	if info.IsDir() {
+		localPath = strings.TrimRight(localPath, string(os.PathSeparator))
+	} else if strings.HasSuffix(localPath, "/") || strings.HasSuffix(localPath, string(os.PathSeparator)) {
+		localPath = filepath.Join(localPath, path.Base(remotePath))
+	}
+
+	label := fmt.Sprintf("get %s:%s → %s", hostName, remotePath, localPath)
+	progress := progressPrinter(label)
+	if err := client.DownloadPath(context.Background(), remotePath, localPath, progress); err != nil {
+		finishProgress()
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+	finishProgress()
+	fmt.Printf("Downloaded %s:%s to %s\n", hostName, remotePath, localPath)
+}
+
+func runSCP(src, dst string) {
+	srcHost, srcRemote, srcIsRemote := ParseTransferTarget(src)
+	dstHost, dstRemote, dstIsRemote := ParseTransferTarget(dst)
+
+	switch {
+	case !srcIsRemote && dstIsRemote:
+		runPut(dstHost, src, dstRemote)
+	case srcIsRemote && !dstIsRemote:
+		runGet(srcHost, srcRemote, dst)
+	case srcIsRemote && dstIsRemote:
+		fmt.Fprintf(os.Stderr, "Error: remote-to-remote copy is not supported\n")
+		os.Exit(1)
+	default:
+		fmt.Fprintf(os.Stderr, "Error: one of src or dst must be host:path\n")
+		os.Exit(1)
+	}
+}
+
+func init() {
+	RootCmd.AddCommand(putCmd)
+	RootCmd.AddCommand(getCmd)
+	RootCmd.AddCommand(scpCmd)
+}

--- a/cmd/transfer_test.go
+++ b/cmd/transfer_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import "testing"
+
+func TestParseTransferTarget(t *testing.T) {
+	tests := []struct {
+		in         string
+		wantHost   string
+		wantRemote string
+		wantOK     bool
+	}{
+		{"web1:/tmp/a", "web1", "/tmp/a", true},
+		{"web1:relative/path", "web1", "relative/path", true},
+		{"web1:", "web1", ".", true},
+		{"./local", "", "", false},
+		{"/abs/path", "", "", false},
+		{"C:/windows/path", "", "", false},
+		{"C:\\windows\\path", "", "", false},
+		{":/nohost", "", "", false},
+		{"path/with:colon", "", "", false}, // host contains slash → local
+		{"user@bastion:/tmp/x", "user@bastion", "/tmp/x", true},
+	}
+	for _, tt := range tests {
+		host, remote, ok := ParseTransferTarget(tt.in)
+		if ok != tt.wantOK || host != tt.wantHost || remote != tt.wantRemote {
+			t.Errorf("ParseTransferTarget(%q) = (%q,%q,%v); want (%q,%q,%v)",
+				tt.in, host, remote, ok, tt.wantHost, tt.wantRemote, tt.wantOK)
+		}
+	}
+}

--- a/internal/config/ssh.go
+++ b/internal/config/ssh.go
@@ -2015,3 +2015,19 @@ func UpdateMultiHostBlock(originalHosts, newHosts []string, commonProperties SSH
 	newContent := strings.Join(newLines, "\n")
 	return os.WriteFile(configPath, []byte(newContent), 0600)
 }
+
+// HostHasTag reports whether the given tag list contains the target tag
+// (case-insensitive; a leading '#' on either side is ignored).
+func HostHasTag(tags []string, target string) bool {
+	return hostHasTag(tags, target)
+}
+
+// HostHasAnyTag reports whether the host has at least one of the given tags.
+func HostHasAnyTag(tags []string, targets []string) bool {
+	for _, t := range targets {
+		if hostHasTag(tags, t) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/serialconfig/serial.go
+++ b/internal/serialconfig/serial.go
@@ -135,3 +135,17 @@ func DefaultDevice() SerialDevice {
 		FlowControl: "none",
 	}
 }
+
+// Find returns the saved serial device with the given name.
+func Find(name string) (SerialDevice, bool) {
+	devices, err := Load()
+	if err != nil {
+		return SerialDevice{}, false
+	}
+	for _, d := range devices {
+		if d.Name == name {
+			return d, true
+		}
+	}
+	return SerialDevice{}, false
+}

--- a/internal/sftpconfig/recursive.go
+++ b/internal/sftpconfig/recursive.go
@@ -1,0 +1,133 @@
+package sftpconfig
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// ProgressFunc reports transfer progress for a single file.
+type ProgressFunc func(transferred, total int64)
+
+// UploadPath uploads a local file or directory to the remote path.
+// Directories are transferred recursively.
+func (c *SFTPClient) UploadPath(ctx context.Context, localPath, remotePath string, progress ProgressFunc) error {
+	info, err := os.Stat(localPath)
+	if err != nil {
+		return fmt.Errorf("local path: %w", err)
+	}
+	if info.IsDir() {
+		return c.uploadDir(ctx, localPath, remotePath, progress)
+	}
+	return c.UploadWithProgressCtx(ctx, localPath, remotePath, progress)
+}
+
+// DownloadPath downloads a remote file or directory to the local path.
+// Directories are transferred recursively.
+func (c *SFTPClient) DownloadPath(ctx context.Context, remotePath, localPath string, progress ProgressFunc) error {
+	info, err := c.Stat(remotePath)
+	if err != nil {
+		return fmt.Errorf("remote path: %w", err)
+	}
+	if info.IsDir() {
+		return c.downloadDir(ctx, remotePath, localPath, progress)
+	}
+	if err := os.MkdirAll(filepath.Dir(localPath), 0755); err != nil {
+		return err
+	}
+	return c.DownloadWithProgressCtx(ctx, remotePath, localPath, progress)
+}
+
+func (c *SFTPClient) uploadDir(ctx context.Context, localDir, remoteDir string, progress ProgressFunc) error {
+	if err := c.MkdirAll(remoteDir); err != nil {
+		return err
+	}
+	entries, err := os.ReadDir(localDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		src := filepath.Join(localDir, entry.Name())
+		dst := path.Join(remoteDir, entry.Name())
+		if entry.IsDir() {
+			if err := c.uploadDir(ctx, src, dst, progress); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := c.UploadWithProgressCtx(ctx, src, dst, progress); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *SFTPClient) downloadDir(ctx context.Context, remoteDir, localDir string, progress ProgressFunc) error {
+	if err := os.MkdirAll(localDir, 0755); err != nil {
+		return err
+	}
+	entries, err := c.ListDir(remoteDir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if entry.Name == "." || entry.Name == ".." {
+			continue
+		}
+		src := path.Join(remoteDir, entry.Name)
+		dst := filepath.Join(localDir, entry.Name)
+		if entry.IsDir {
+			if err := c.downloadDir(ctx, src, dst, progress); err != nil {
+				return err
+			}
+			continue
+		}
+		if err := c.DownloadWithProgressCtx(ctx, src, dst, progress); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// MkdirAll creates a remote directory and any missing parents.
+func (c *SFTPClient) MkdirAll(remotePath string) error {
+	remotePath = path.Clean(remotePath)
+	if remotePath == "." || remotePath == "/" {
+		return nil
+	}
+	parts := strings.Split(remotePath, "/")
+	cur := ""
+	if strings.HasPrefix(remotePath, "/") {
+		cur = "/"
+	}
+	for _, p := range parts {
+		if p == "" || p == "." {
+			continue
+		}
+		if cur == "/" {
+			cur = "/" + p
+		} else if cur == "" {
+			cur = p
+		} else {
+			cur = path.Join(cur, p)
+		}
+		info, err := c.Stat(cur)
+		if err == nil {
+			if !info.IsDir() {
+				return fmt.Errorf("%s exists and is not a directory", cur)
+			}
+			continue
+		}
+		if err := c.Mkdir(cur); err != nil {
+			// Race or already exists — re-stat
+			if info, err2 := c.Stat(cur); err2 == nil && info.IsDir() {
+				continue
+			}
+			return fmt.Errorf("mkdir %s: %w", cur, err)
+		}
+	}
+	return nil
+}

--- a/internal/ui/sftp_view.go
+++ b/internal/ui/sftp_view.go
@@ -51,13 +51,13 @@ type sftpFormModel struct {
 	password  string
 
 	// Download/upload progress (shared between goroutine and TUI)
-	progressDone  int64
-	progressTotal int64
-	progressFile  string
-	progressGen   int
-	transferring  bool
+	progressDone   int64
+	progressTotal  int64
+	progressFile   string
+	progressGen    int
+	transferring   bool
 	transferCancel context.CancelFunc // cancels the in-flight upload/download goroutine
-	queue         sftpTransferQueue
+	queue          sftpTransferQueue
 
 	// For input modes
 	inputBuffer string

--- a/skills/ctty/SKILL.md
+++ b/skills/ctty/SKILL.md
@@ -18,20 +18,21 @@ the ctty config dir. Agents must drive it **non-interactively**.
 
 | Kind | Agent can | Hand to the human |
 |------|-----------|-------------------|
-| SSH | `search`, `info`, `ctty <alias> -- <cmd>` | `ctty <alias>` shell, port-forward TUI (`f`) |
-| SFTP | `scp`/`rsync`/`sftp` with the same alias | `ctty sftp <alias>` |
-| Telnet | Read `telnet.json`; quote `ctty telnet <name>` | Interactive session (`Ctrl+]`) |
-| Serial | Read `serial.json`; quote `ctty serial` | Device manager TUI |
+| SSH | `search`, `info`, `add`/`edit` (flags), `exec`, `ctty <alias> -- <cmd>` | `ctty <alias>` shell, port-forward TUI (`f`) |
+| SFTP | `ctty put` / `ctty get` / `ctty scp` (preferred); or OpenSSH `scp`/`rsync` | `ctty sftp <alias>` TUI |
+| Telnet | `ctty telnet list|search|info --format json` | Interactive session (`Ctrl+]`) |
+| Serial | `ctty serial list|search|info --format json` | Device manager TUI |
 | Import | `ctty import tabby --dry-run` then import | Confirm overwrite / Include |
 
 ## Hard rules
 
 1. **Never launch the TUI.** These hang a non-TTY agent session:
    - `ctty` with no args
-   - `ctty add` / `ctty edit` / `ctty move`
-   - `ctty sftp <host>`
-   - `ctty serial` (always TUI)
-   - `ctty telnet` with no argument (manager TUI)
+   - `ctty add` / `ctty edit` **without** host-config flags (use flags / `--non-interactive`)
+   - `ctty move`
+   - `ctty sftp <host>` (use `put`/`get`/`scp` instead)
+   - `ctty serial` with no subcommand (use `list|search|info`)
+   - `ctty telnet` with no argument (manager TUI; use `list|search|info`)
    - `ctty telnet <name-or-host>` (raw interactive session)
    - `ctty <host>` with **no remote command** (interactive SSH)
 2. **Prefer ctty's aliases over raw `ssh`/`scp`/`telnet`.** SSH goes through
@@ -157,32 +158,55 @@ ctty --lang en --no-update-check -t prod-web -- sudo systemctl restart nginx
   it to open a shell
 - Do not start `vim`, `less`, `top`, or an interactive shell
 
-### 4. SFTP / files
+### 3b. SSH — add / edit hosts (non-interactive)
 
-`ctty sftp <alias>` is a TUI. For agents, use OpenSSH with the **same Host
-alias**:
+Non-interactive mode triggers when `--non-interactive` is set **or** any of
+`--name`, `--hostname`, `--user`, `--port`, `--identity-file`, `--proxy-jump`,
+`--proxy-command`, `--option`/`-o`, `--tags`, `--password`, `--force` is
+provided. Otherwise the TUI form opens — never do that from an agent.
 
 ```bash
-scp prod-web:/var/log/nginx/error.log /tmp/
-scp ./deploy.sh prod-web:/tmp/
-rsync -az ./out/ prod-web:/opt/app/
-sftp prod-web
+ctty --lang en --no-update-check add --name web1 --hostname 10.0.0.1 --user deploy --tags prod,web --format json
+ctty --lang en --no-update-check add --name web1 --hostname 10.0.0.1 --force --format json
+ctty --lang en --no-update-check edit web1 --port 2222 --tags prod,api --format json
 ```
 
-Do not send files to `~/Downloads/ctty` unless the user asked; put them where
-the task needs them. `sftp` without a batch file is still interactive — prefer
-`scp`/`rsync`.
+`--password` is optional and stored only in the credential vault (never SSH
+config, never printed). `-c` selects a custom SSH config file.
+
+### 3c. SSH — batch exec
+
+```bash
+ctty --lang en --no-update-check exec --tags prod -- uptime
+ctty --lang en --no-update-check exec --hosts web1,web2 --concurrency 4 --format json -- df -h
+```
+
+Aggregate exit 0 iff all hosts succeed. JSON items: `{host,ok,exit_code,stdout,stderr}`.
+
+### 4. SFTP / files
+
+Prefer ctty's built-in transfer (uses the same Host alias + credential vault):
+
+```bash
+ctty --lang en --no-update-check put prod-web ./deploy.sh /tmp/deploy.sh
+ctty --lang en --no-update-check get prod-web /var/log/app.log ./app.log
+ctty --lang en --no-update-check scp ./out/ prod-web:/opt/app/
+ctty --lang en --no-update-check scp prod-web:/var/log/nginx/error.log /tmp/
+```
+
+Progress is on stderr; exit non-zero on failure; directories are recursive.
+`ctty sftp <alias>` remains a TUI — do not open it. OpenSSH `scp`/`rsync` with
+the same alias is still fine as a fallback.
 
 ### 5. Telnet
 
-Saved devices: `~/.config/ctty/telnet.json` (Windows: `%APPDATA%\ctty\telnet.json`).
-List with `jq`; do not start a session.
-
 ```bash
-jq '.hosts[] | {name, host, port, tags}' ~/.config/ctty/telnet.json
+ctty --lang en --no-update-check telnet list --format json
+ctty --lang en --no-update-check telnet search lab --format json
+ctty --lang en --no-update-check telnet info core-sw --format json
 ```
 
-Connect commands for the human (cleartext; prefer SSH if the box has it):
+Do not start a session. Quote connect commands for the human (cleartext):
 
 ```text
 ctty telnet core-sw          # saved name
@@ -190,19 +214,18 @@ ctty telnet 192.168.1.1      # port 23
 ctty telnet 10.0.0.5:2001    # explicit port
 ```
 
-Disconnect: `Ctrl+]`. Missing file ⇒ no saved devices, not an error.
+Disconnect: `Ctrl+]`. Missing store ⇒ empty list, not an error.
 
 ### 6. Serial
 
-Saved devices: `~/.config/ctty/serial.json`. Auto-detected ports only appear
-inside the TUI.
-
 ```bash
-jq '.devices[] | {name, device, baud_rate, data_bits, parity, stop_bits}' ~/.config/ctty/serial.json
+ctty --lang en --no-update-check serial list --format json
+ctty --lang en --no-update-check serial search usb --format json
+ctty --lang en --no-update-check serial info Switch-Console --format json
 ```
 
-There is no `ctty serial <name>` CLI. Tell the user to run `ctty serial` and
-pick the device. Disconnect: `Ctrl+]` or `Ctrl+C`.
+Auto-detected ports only appear inside the TUI. Quote `ctty serial` for the
+human to connect. Disconnect: `Ctrl+]` or `Ctrl+C`.
 
 ### 7. Import (Tabby → SSH)
 
@@ -223,15 +246,16 @@ names are skipped.
 | Request | Agent does | Human does |
 |---------|------------|------------|
 | "SSH into prod" | `info` + remote commands, or quote `ctty prod` | Interactive SSH |
-| "SFTP / copy files" | `scp`/`rsync` with the alias | `ctty sftp host` |
-| "Telnet to the switch" | List `telnet.json`, quote `ctty telnet <name>` | Interactive telnet |
-| "Open serial / console" | List `serial.json`, quote `ctty serial` | Serial TUI |
+| "SFTP / copy files" | `ctty put`/`get`/`scp` (or OpenSSH) | `ctty sftp host` |
+| "Telnet to the switch" | `telnet list|search|info --format json`, quote connect | Interactive telnet |
+| "Open serial / console" | `serial list|search|info --format json`, quote `ctty serial` | Serial TUI |
 | "Port forward" | Explain `-L`/`-R`/`-D`; do not open TUI | `f` in the host list |
-| "Add a host" | Append a `Host` block (see [reference.md](references/reference.md)) | `ctty add` |
+| "Add a host" | `ctty add --name … --hostname …` (non-interactive flags) | `ctty add` TUI |
 | "Import Tabby" | `import tabby --dry-run`, then import if asked | Confirm result |
 
 Do not treat Cobra subcommand names as SSH hosts: `add`, `edit`, `move`,
-`search`, `info`, `sftp`, `serial`, `telnet`, `import`, `update`, `completion`.
+`search`, `info`, `sftp`, `serial`, `telnet`, `import`, `update`, `completion`,
+`put`, `get`, `scp`, `exec`.
 
 ## Examples
 
@@ -257,7 +281,8 @@ Quote: `ctty Netease`. Do not execute it.
 **User:** "连实验室那台 telnet 交换机"
 
 ```bash
-jq '.hosts[] | {name, host, port, tags}' ~/.config/ctty/telnet.json
+ctty --lang en --no-update-check telnet search 交换机 --format json
+# or: ctty telnet list --format json
 ```
 
 Then quote `ctty telnet core-sw` (or whatever `name` matched). Do not run it.
@@ -265,7 +290,7 @@ Then quote `ctty telnet core-sw` (or whatever `name` matched). Do not run it.
 **User:** "串口连交换机"
 
 ```bash
-jq '.devices[]' ~/.config/ctty/serial.json
+ctty --lang en --no-update-check serial list --format json
 ```
 
 Then quote `ctty serial`.


### PR DESCRIPTION
…elnet

Add non-interactive CLI support for agents to drive ctty without the TUI:

- SSH:
  - `add`/`edit` with host-config flags (--name, --hostname, --user, etc.)
  - `exec` for batch remote commands (--tags, --hosts, --concurrency)
  - JSON output for agent-friendly success payloads (--format json)

- SFTP:
  - `put`/`get`/`scp` file transfer (recursive directories, progress on stderr)

- Serial/Telnet:
  - `list|search|info` with JSON output (--format json)
  - No-args still opens the TUI; `ctty telnet <name>` connect is unchanged

- Documentation:
  - Add ctty agent skill documentation and usage guide
  - Update SKILL.md with non-interactive CLI usage examples

BREAKING CHANGE: `ctty add`/`edit` now requires --name (or positional alias) and --hostname in non-interactive mode.