### PR TITLE
feat(ui): improve SFTP form page layout and error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **SFTP upload local browse (Windows)** — Upload picker starts in the process working directory (where ctty was launched) instead of the user home. At a drive root (`C:\`), ← opens a drive list so other volumes are reachable; it no longer jumps back to the remote browser. Tab/Esc still return to remote.
 - **SFTP upload local browse (Unix)** — At filesystem root `/`, ← stays on the local picker instead of switching to remote (Tab/Esc still leave).
+- **SFTP connecting / password / error layout** — Those full-page SFTP states use `renderFormPage` so the bordered box tracks terminal width on resize; long error text wraps inside the box.
 
 ## [0.6.2] - 2026-09-07
 

--- a/internal/ui/sftp_error_layout_test.go
+++ b/internal/ui/sftp_error_layout_test.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestSFTPErrorViewScalesWithTerminalWidth(t *testing.T) {
+	styles := NewStyles(80)
+	m := NewSFTPForm(styles, 80, 24, "server1", "")
+	m.mode = sftpError
+	m.loadError = strings.Repeat("hostkey-mismatch-", 20)
+
+	var prev int
+	for _, w := range []int{40, 80, 120} {
+		m.width = w
+		m.height = 24
+		view := m.renderErrorView()
+		got := lipgloss.Width(view)
+		if got > w {
+			t.Fatalf("width=%d: rendered %d wider than terminal", w, got)
+		}
+		if prev != 0 && got < prev {
+			t.Fatalf("width=%d: rendered %d did not grow with terminal (prev %d)", w, got, prev)
+		}
+		// Box should track terminal (App + FormContainer ≈ full width).
+		if w >= 40 && got < w-4 {
+			t.Fatalf("width=%d: rendered %d too narrow (expected near full width)", w, got)
+		}
+		prev = got
+	}
+}

--- a/internal/ui/sftp_view.go
+++ b/internal/ui/sftp_view.go
@@ -998,20 +998,18 @@ func (m *sftpFormModel) handleUploadSearchKeys(msg tea.KeyMsg) (tea.Model, tea.C
 // View renders the SFTP browser
 func (m *sftpFormModel) View() string {
 	if m.loading && m.client == nil {
-		return m.styles.FormContainer.Render(
-			m.styles.FormTitle.Render(" "+i18n.T("sftp.title_remote", m.hostName)+" ") + "\n\n" +
-				"  " + i18n.T("sftp.connecting", m.hostName),
-		)
+		body := m.styles.FormTitle.Render(" "+i18n.T("sftp.title_remote", m.hostName)+" ") + "\n\n" +
+			"  " + i18n.T("sftp.connecting", m.hostName)
+		return renderFormPage(m.styles, m.width, body)
 	}
 
 	if m.mode == sftpPasswordInput {
-		return m.styles.FormContainer.Render(
-			m.styles.FormTitle.Render(" SFTP - Password ") + "\n\n" +
-				fmt.Sprintf("  %s\n", m.inputPrompt) +
-				fmt.Sprintf("  %s_\n", strings.Repeat("*", len(m.inputBuffer))) +
-				"\n" +
-				m.styles.HelpText.Render("  Enter: connect • Esc: cancel"),
-		)
+		body := m.styles.FormTitle.Render(" SFTP - Password ") + "\n\n" +
+			fmt.Sprintf("  %s\n", m.inputPrompt) +
+			fmt.Sprintf("  %s_\n", strings.Repeat("*", len(m.inputBuffer))) +
+			"\n" +
+			m.styles.HelpText.Render("  Enter: connect • Esc: cancel")
+		return renderFormPage(m.styles, m.width, body)
 	}
 
 	if m.mode == sftpError {
@@ -1106,17 +1104,19 @@ func (m *sftpFormModel) View() string {
 }
 
 func (m *sftpFormModel) renderErrorView() string {
+	inner := formPageInnerWidth(m.width)
 	errStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color("9")).
 		Bold(true).
-		Padding(1, 2)
+		Padding(1, 2).
+		Width(inner)
 
 	detail := m.loadError
 	if detail == "" {
 		detail = "(no details)"
 	}
 	content := i18n.T("sftp.err_session", detail)
-	return m.styles.FormContainer.Render(errStyle.Render(content))
+	return renderFormPage(m.styles, m.width, errStyle.Render(content))
 }
 
 func (m *sftpFormModel) renderInputLine() string {


### PR DESCRIPTION
Improve the SFTP form page layout and error handling:

- Extract `renderFormPage` helper for consistent full-page layout
- Make error view content wrap inside the bordered box
- Ensure form page content scales with terminal width
- Add test for error view scaling behavior

BREAKING CHANGE: The SFTP form page layout has been refactored to use a new `renderFormPage` helper function, which may affect custom styling or layout expectations.