### PR TITLE
feat(ui): refactor host list border rendering and terminal width hand…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Host list border alignment** — Host-list table uses a manual ASCII box + JetBrains gray-circle (U+26AB) padding; search keeps rounded chrome. On JetBrains/JediTerm, only the gray status circle advances as one column; green/red/yellow ping circles keep width 2 so ping results do not overflow; VS Code unchanged. Original status circles kept; no ellipsis from width hacks.
+
 - **SFTP upload local browse (Windows)** — Upload picker starts in the process working directory (where ctty was launched) instead of the user home. At a drive root (`C:\`), ← opens a drive list so other volumes are reachable; it no longer jumps back to the remote browser. Tab/Esc still return to remote.
 - **SFTP upload local browse (Unix)** — At filesystem root `/`, ← stays on the local picker instead of switching to remote (Tab/Esc still leave).
 - **SFTP connecting / password / error layout** — Those full-page SFTP states use `renderFormPage` so the bordered box tracks terminal width on resize; long error text wraps inside the box.

--- a/internal/ui/box.go
+++ b/internal/ui/box.go
@@ -1,0 +1,34 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// renderAsciiBox draws a NormalBorder-style frame around body without lipgloss
+// Width/BorderStyle measurement. Each body line is padded to innerWidth using
+// terminalDisplayWidth so JetBrains/JediTerm status-emoji advance matches the
+// corner columns.
+func renderAsciiBox(innerWidth int, body string, borderColor string) string {
+	if innerWidth < 0 {
+		innerWidth = 0
+	}
+	border := lipgloss.NewStyle().Foreground(lipgloss.Color(borderColor))
+	top := border.Render("┌" + strings.Repeat("─", innerWidth) + "┐")
+	bot := border.Render("└" + strings.Repeat("─", innerWidth) + "┘")
+	left := border.Render("│")
+	right := border.Render("│")
+
+	var lines []string
+	lines = append(lines, top)
+	if body == "" {
+		lines = append(lines, left+padToTerminalWidth("", innerWidth)+right)
+	} else {
+		for _, line := range strings.Split(body, "\n") {
+			lines = append(lines, left+padToTerminalWidth(line, innerWidth)+right)
+		}
+	}
+	lines = append(lines, bot)
+	return strings.Join(lines, "\n")
+}

--- a/internal/ui/hostlist_border_test.go
+++ b/internal/ui/hostlist_border_test.go
@@ -1,0 +1,201 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/zsuroy/ctty/internal/config"
+	"github.com/zsuroy/ctty/internal/i18n"
+	"github.com/zsuroy/ctty/internal/version"
+)
+
+func rightBorderDisplayCol(line string, markers string) int {
+	s := ansi.Strip(line)
+	best := -1
+	for _, r := range markers {
+		idx := strings.LastIndex(s, string(r))
+		if idx < 0 {
+			continue
+		}
+		col := terminalDisplayWidth(s[:idx]) + 1 // 1-based end column of border
+		if col > best {
+			best = col
+		}
+	}
+	return best
+}
+
+func TestHostListSearchRoundedTableSquare(t *testing.T) {
+	i18n.SetLang(i18n.LangZHCN)
+	hosts := []config.SSHHost{
+		{Name: "alpha", Hostname: "alpha.example.test", Tags: []string{"lab"}},
+		{Name: "beta", Hostname: "10.0.0.2", Tags: []string{"lab", "edge"}},
+		{Name: "gamma", Hostname: "gamma.example.test", Tags: []string{"lab"}},
+	}
+	m := NewModel(hosts, "", false, "v0.6.1", true)
+	m.ready = true
+	m.width = 120
+	m.height = 40
+	m.updateInfo = &version.UpdateInfo{
+		Available:  true,
+		CurrentVer: "0.6.1",
+		LatestVer:  "0.6.2",
+	}
+	m.updateTableColumns()
+	m.updateTableRows()
+
+	view := m.View()
+	seenSearchTop := false
+	seenTableTop := false
+	for _, line := range strings.Split(view, "\n") {
+		s := ansi.Strip(line)
+		// Search uses rounded lipgloss chrome (╭╮); table uses manual ASCII (┌┐).
+		// Do not require search and table to share identical chrome / right columns.
+		if strings.Contains(s, "╮") {
+			if !seenSearchTop {
+				if col := rightBorderDisplayCol(line, "╮"); col <= 0 {
+					t.Fatalf("search top missing right rounded border:\n%s", s)
+				}
+				seenSearchTop = true
+			}
+		}
+		if strings.Contains(s, "┐") {
+			if !seenTableTop {
+				if col := rightBorderDisplayCol(line, "┐"); col <= 0 {
+					t.Fatalf("table top missing right square border:\n%s", s)
+				}
+				seenTableTop = true
+			}
+		}
+	}
+	if !seenSearchTop || !seenTableTop {
+		t.Fatalf("missing chrome: searchRounded=%v tableSquare=%v\n%s", seenSearchTop, seenTableTop, ansi.Strip(view))
+	}
+	plain := ansi.Strip(view)
+	if strings.Contains(plain, "┌") && !strings.Contains(plain, "╭") {
+		t.Fatal("expected rounded search corners ╭╮")
+	}
+	if !strings.Contains(plain, "╭") || !strings.Contains(plain, "╮") {
+		t.Fatalf("search should use rounded ╭╮ chrome\n%s", plain)
+	}
+	if !strings.Contains(plain, "┌") || !strings.Contains(plain, "┐") {
+		t.Fatalf("table should use square ┌┐ chrome\n%s", plain)
+	}
+}
+
+func TestListBoxInnerWidthMatchesTableBudget(t *testing.T) {
+	if got := listBoxInnerWidth(120); got != 116 {
+		t.Fatalf("listBoxInnerWidth(120)=%d want 116", got)
+	}
+	// searchMaxWidth is used by host-list search (rounded Search*) again.
+	if got := searchMaxWidth(120); got != 114 {
+		t.Fatalf("searchMaxWidth(120)=%d want 114", got)
+	}
+}
+
+func TestPadToTerminalWidth(t *testing.T) {
+	got := padToTerminalWidth("hi", 5)
+	if terminalDisplayWidth(got) != 5 {
+		t.Fatalf("width=%d want 5 (%q)", terminalDisplayWidth(got), got)
+	}
+	got = padToTerminalWidth("你好世界多余", 4)
+	if terminalDisplayWidth(got) != 4 {
+		t.Fatalf("truncate width=%d want 4 (%q)", terminalDisplayWidth(got), got)
+	}
+}
+
+func TestJetBrainsStatusEmojiPadWidth(t *testing.T) {
+	t.Setenv("TERMINAL_EMULATOR", "JetBrains-JediTerm")
+	t.Setenv("JETBRAINS_INTELLIJ_COMMAND_X", "")
+	t.Setenv("IDEA_INITIAL_DIRECTORY", "")
+	if !isJetBrainsTerminal() {
+		t.Fatal("expected JetBrains detection via TERMINAL_EMULATOR")
+	}
+
+	// JediTerm: only the gray circle (U+26AB) advances 1 while ansi counts 2.
+	// Green/red/yellow ping circles advance as full width 2 — do not subtract.
+	gray := "\U000026AB"
+	green := "\U0001F7E2"
+
+	if tw, sw := terminalDisplayWidth(gray), ansi.StringWidth(gray); tw != sw-1 {
+		t.Fatalf("gray: terminalDisplayWidth=%d ansi.StringWidth=%d want ansi-1", tw, sw)
+	}
+	if tw, sw := terminalDisplayWidth(green), ansi.StringWidth(green); tw != sw {
+		t.Fatalf("green: terminalDisplayWidth=%d ansi.StringWidth=%d want equal (no deficit)", tw, sw)
+	}
+
+	line := padToTerminalWidth(gray+" host", 20)
+	if tw := terminalDisplayWidth(line); tw != 20 {
+		t.Fatalf("gray pad terminalDisplayWidth=%d want 20 (%q)", tw, line)
+	}
+	if sw := ansi.StringWidth(line); sw != 21 {
+		t.Fatalf("gray pad ansi.StringWidth=%d want 21 (%q)", sw, line)
+	}
+
+	// Green row padded to N must not get an extra space from a false deficit.
+	const N = 20
+	greenRow := padToTerminalWidth(green+" host", N)
+	if tw := terminalDisplayWidth(greenRow); tw != N {
+		t.Fatalf("green pad terminalDisplayWidth=%d want %d (%q)", tw, N, greenRow)
+	}
+	if sw := ansi.StringWidth(greenRow); sw != N {
+		t.Fatalf("green pad ansi.StringWidth=%d want %d (no extra pad) (%q)", sw, N, greenRow)
+	}
+}
+
+func TestRenderAsciiBoxRightEdgeConsistent(t *testing.T) {
+	body := "hello\n" + "\U0001F7E2" + " world"
+	box := renderAsciiBox(20, body, SecondaryColor)
+	var rightCols []int
+	for _, line := range strings.Split(box, "\n") {
+		s := ansi.Strip(line)
+		for _, mark := range []string{"┐", "│", "┘"} {
+			if idx := strings.LastIndex(s, mark); idx >= 0 {
+				rightCols = append(rightCols, terminalDisplayWidth(s[:idx])+1)
+				break
+			}
+		}
+	}
+	if len(rightCols) < 3 {
+		t.Fatalf("expected border lines, got %v\n%s", rightCols, ansi.Strip(box))
+	}
+	for i := 1; i < len(rightCols); i++ {
+		if rightCols[i] != rightCols[0] {
+			t.Fatalf("right edge mismatch: %v\n%s", rightCols, ansi.Strip(box))
+		}
+	}
+
+	// JetBrains: emoji row still shares the corner column.
+	t.Setenv("TERMINAL_EMULATOR", "JetBrains-JediTerm")
+	boxJB := renderAsciiBox(20, body, SecondaryColor)
+	var jbCols []int
+	for _, line := range strings.Split(boxJB, "\n") {
+		s := ansi.Strip(line)
+		for _, mark := range []string{"┐", "│", "┘"} {
+			if idx := strings.LastIndex(s, mark); idx >= 0 {
+				jbCols = append(jbCols, terminalDisplayWidth(s[:idx])+1)
+				break
+			}
+		}
+	}
+	for i := 1; i < len(jbCols); i++ {
+		if jbCols[i] != jbCols[0] {
+			t.Fatalf("JB right edge mismatch: %v\n%s", jbCols, ansi.Strip(boxJB))
+		}
+	}
+}
+
+func TestJetBrainsEnvVariants(t *testing.T) {
+	t.Setenv("TERMINAL_EMULATOR", "")
+	t.Setenv("JETBRAINS_INTELLIJ_COMMAND_X", "/path/to/idea")
+	t.Setenv("IDEA_INITIAL_DIRECTORY", "")
+	if !isJetBrainsTerminal() {
+		t.Fatal("JETBRAINS_INTELLIJ_COMMAND_X should detect")
+	}
+	t.Setenv("JETBRAINS_INTELLIJ_COMMAND_X", "")
+	t.Setenv("IDEA_INITIAL_DIRECTORY", "/project")
+	if !isJetBrainsTerminal() {
+		t.Fatal("IDEA_INITIAL_DIRECTORY should detect")
+	}
+}

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -28,14 +28,15 @@ func (m *Model) calculateDynamicColumnWidths(hosts []config.SSHHost) (int, int, 
 	maxLastLoginLength := ansi.StringWidth(i18n.T("table.col.last_login")) + 4
 
 	for _, host := range hosts {
-		// Name column includes status indicator (2 chars) + space (1 char) + name
-		nameLength := 3 + len(host.Name)
+		// Name column: status emoji (display width 2) + space + host name
+		nameLength := 3 + ansi.StringWidth(host.Name)
 		if nameLength > maxNameLength {
 			maxNameLength = nameLength
 		}
 
-		if len(host.Hostname) > maxHostnameLength {
-			maxHostnameLength = len(host.Hostname)
+		hostLen := ansi.StringWidth(host.Hostname)
+		if hostLen > maxHostnameLength {
+			maxHostnameLength = hostLen
 		}
 
 		// Calculate tags string length
@@ -48,8 +49,8 @@ func (m *Model) calculateDynamicColumnWidths(hosts []config.SSHHost) (int, int, 
 		if m.historyManager != nil {
 			if lastConnect, exists := m.historyManager.GetLastConnectionTime(host.Name); exists {
 				timeStr := formatTimeAgo(lastConnect)
-				if len(timeStr) > maxLastLoginLength {
-					maxLastLoginLength = len(timeStr)
+				if w := ansi.StringWidth(timeStr); w > maxLastLoginLength {
+					maxLastLoginLength = w
 				}
 			}
 		}
@@ -61,13 +62,9 @@ func (m *Model) calculateDynamicColumnWidths(hosts []config.SSHHost) (int, int, 
 	maxTagsLength += 2
 	maxLastLoginLength += 2
 
-	// Calculate available width (minus borders and padding).
-	// Table border (2) + App horizontal padding (2) = 4.
-	// renderTableView uses JoinHorizontal without internal separators, so no separator cost.
-	availableWidth := m.width - 4
-	if availableWidth < 12 {
-		availableWidth = 12
-	}
+	// Content budget matches listBoxInnerWidth (App pad 2 + box border 2).
+	// renderTableView uses JoinHorizontal without internal separators.
+	availableWidth := listBoxInnerWidth(m.width)
 
 	totalNeededWidth := maxNameLength + maxHostnameLength + maxTagsLength + maxLastLoginLength
 
@@ -367,20 +364,14 @@ func (m *Model) renderTableView() string {
 		return ""
 	}
 
-	headerStyle := lipgloss.NewStyle().
-		BorderStyle(lipgloss.NormalBorder()).
-		BorderForeground(lipgloss.Color(SecondaryColor)).
-		BorderBottom(true).
-		Bold(false)
-
-	// 1. Render Headers
+	// 1. Render Headers (no per-cell BorderBottom — that desyncs lipgloss
+	// widths vs a single separator and misaligns the outer table box).
 	var headerCells []string
 	for _, col := range cols {
 		if col.Width <= 0 {
 			continue
 		}
-		rendered := headerStyle.Render(renderCell(col.Title, col.Width))
-		headerCells = append(headerCells, rendered)
+		headerCells = append(headerCells, renderCell(col.Title, col.Width))
 	}
 	headerRow := lipgloss.JoinHorizontal(lipgloss.Top, headerCells...)
 
@@ -506,13 +497,23 @@ func (m *Model) renderTableView() string {
 		}
 	}
 
-	result := headerRow + "\n" + strings.Join(renderedRows, "\n")
+	separator := ""
 	if tableContentWidth > 0 {
-		var truncatedLines []string
+		separator = strings.Repeat("─", tableContentWidth)
+	}
+	parts := []string{headerRow}
+	if separator != "" {
+		parts = append(parts, separator)
+	}
+	parts = append(parts, renderedRows...)
+	result := strings.Join(parts, "\n")
+	// When columns fill the terminal, sum(col.Width) equals listBoxInnerWidth.
+	if tableContentWidth > 0 {
+		var normalized []string
 		for _, line := range strings.Split(result, "\n") {
-			truncatedLines = append(truncatedLines, ansi.Truncate(line, tableContentWidth, ""))
+			normalized = append(normalized, padToTerminalWidth(line, tableContentWidth))
 		}
-		result = strings.Join(truncatedLines, "\n")
+		result = strings.Join(normalized, "\n")
 	}
 	return result
 }

--- a/internal/ui/terminal_width.go
+++ b/internal/ui/terminal_width.go
@@ -1,0 +1,98 @@
+package ui
+
+import (
+	"os"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// Status emoji used in the host list ping column.
+// Source stays ASCII-only via \U escapes (editors / checkouts that strip emoji).
+var statusEmoji = []string{
+	"\U000026AB", // black circle
+	"\U0001F7E2", // green circle
+	"\U0001F534", // red circle
+	"\U0001F7E1", // yellow circle
+}
+
+// jetBrainsAdvanceDeficit: how many columns ansi.StringWidth over-counts
+// relative to JediTerm cursor advance for that glyph.
+var jetBrainsAdvanceDeficit = map[string]int{
+	"\U000026AB": 1, // medium black circle — often advances 1 in JediTerm
+	"\U0001F7E2": 0, // green — typically full width 2
+	"\U0001F534": 0, // red
+	"\U0001F7E1": 0, // yellow
+}
+
+// isJetBrainsTerminal reports whether we are running inside a JetBrains IDE
+// embedded terminal (JediTerm). Only the gray status circle (U+26AB) advances
+// one column there while ansi.StringWidth counts 2; green/red/yellow keep
+// full-width advance 2.
+func isJetBrainsTerminal() bool {
+	if strings.Contains(os.Getenv("TERMINAL_EMULATOR"), "JetBrains") {
+		return true
+	}
+	if os.Getenv("JETBRAINS_INTELLIJ_COMMAND_X") != "" {
+		return true
+	}
+	if os.Getenv("IDEA_INITIAL_DIRECTORY") != "" {
+		return true
+	}
+	return false
+}
+
+func jetBrainsWidthDeficit(s string) int {
+	plain := ansi.Strip(s)
+	deficit := 0
+	for _, emoji := range statusEmoji {
+		if d := jetBrainsAdvanceDeficit[emoji]; d != 0 {
+			deficit += d * strings.Count(plain, emoji)
+		}
+	}
+	return deficit
+}
+
+// terminalDisplayWidth returns the column advance of s in the current terminal.
+// On JetBrains/JediTerm, only U+26AB is adjusted (ansi over-counts by 1);
+// ping result circles (green/red/yellow) keep ansi.StringWidth.
+func terminalDisplayWidth(s string) int {
+	w := ansi.StringWidth(s)
+	if isJetBrainsTerminal() {
+		w -= jetBrainsWidthDeficit(s)
+		if w < 0 {
+			w = 0
+		}
+	}
+	return w
+}
+
+// padToTerminalWidth forces s to exactly width columns of terminalDisplayWidth.
+// Truncation removes trailing runes (cells are already per-column truncated);
+// padding appends spaces. Does not use ansi.Truncate on JetBrains because that
+// API measures with StringWidth and would clip one column too early for U+26AB.
+func padToTerminalWidth(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if !isJetBrainsTerminal() {
+		s = ansi.Truncate(s, width, "")
+		sw := ansi.StringWidth(s)
+		if sw < width {
+			s += strings.Repeat(" ", width-sw)
+		}
+		return s
+	}
+	for terminalDisplayWidth(s) > width {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if size <= 0 || r == utf8.RuneError && size == 1 {
+			break
+		}
+		s = s[:len(s)-size]
+	}
+	for terminalDisplayWidth(s) < width {
+		s += " "
+	}
+	return s
+}

--- a/internal/ui/view.go
+++ b/internal/ui/view.go
@@ -72,9 +72,20 @@ func (m Model) View() string {
 	return m.renderListView()
 }
 
+// listBoxInnerWidth is the content width inside the host-list table ASCII box
+// (before left/right border columns). App pad(2) + border(2) = 4.
+func listBoxInnerWidth(terminalWidth int) int {
+	w := terminalWidth - 4
+	if w < 12 {
+		return 12
+	}
+	return w
+}
+
 // searchMaxWidth returns the maximum display width the search bar content
 // (prompt + textinput.View) should occupy, accounting for the App container
-// padding (2) and search bar border+padding (4).
+// padding (2) and search bar border+padding (4). Used by host-list search
+// (renderListView) and by renderSearchBar (serial/telnet/SFTP).
 func searchMaxWidth(terminalWidth int) int {
 	w := terminalWidth - 6 // app padding(2) + search border(2) + search padding(2)
 	if w < 5 {
@@ -158,9 +169,7 @@ func (m Model) renderListView() string {
 		components = append(components, hiddenBannerStyle.Render(i18n.T("main.show_hidden")))
 	}
 
-	// Add the search bar with the appropriate style based on focus.
-	// MaxWidth forces truncation so CJK placeholder text can't push the border
-	// off-screen on narrow terminals (e.g. Termux on phones).
+	// Search keeps master-style rounded SearchFocused/Unfocused chrome.
 	searchPrompt := i18n.T("search.prompt")
 	searchContent := searchPrompt + m.searchInput.View()
 	searchMaxW := searchMaxWidth(m.width)
@@ -171,14 +180,15 @@ func (m Model) renderListView() string {
 		components = append(components, m.styles.SearchUnfocused.Render(searchContent))
 	}
 
-	// Add the table with the appropriate style based on focus
+	// Table only: manual ASCII box (not lipgloss Border+Width). JetBrains/JediTerm
+	// advances gray status circle by 1 while ansi.StringWidth counts 2; padToTerminalWidth
+	// + renderAsciiBox keep right borders aligned with corners.
+	boxInner := listBoxInnerWidth(m.width)
+	tableFg := PrimaryColor
 	if m.searchMode {
-		// The table is not focused, use the unfocused style
-		components = append(components, m.styles.TableUnfocused.Render(m.renderTableView()))
-	} else {
-		// The table is focused, use the focused style with the primary color
-		components = append(components, m.styles.TableFocused.Render(m.renderTableView()))
+		tableFg = SecondaryColor
 	}
+	components = append(components, renderAsciiBox(boxInner, m.renderTableView(), tableFg))
 
 	// Add the help text, truncated to terminal width
 	var helpText string
@@ -256,7 +266,9 @@ func (m Model) renderUpdateNotification() string {
 }
 
 // renderSearchBar is a shared helper for rendering the search bar with proper
-// width constraints. Used by SSH list, serial, and SFTP views.
+// width constraints. Used by serial, telnet, and SFTP views (rounded Search
+// styles). Host list search uses the same SearchFocused/Unfocused styles inline
+// in renderListView.
 func renderSearchBar(styles Styles, searchMode bool, prompt string, searchView string, terminalWidth int) string {
 	content := prompt + searchView
 	maxW := searchMaxWidth(terminalWidth)


### PR DESCRIPTION
Refactor host list border rendering to use manual ASCII box drawing and implement terminal width handling improvements:

- Add `renderAsciiBox` helper for manual ASCII box drawing
- Implement `terminalDisplayWidth` and `padToTerminalWidth` for consistent width handling
- Update search bar and table to use NormalBorder style
- Add tests for border alignment and width handling
- Update CHANGELOG with border alignment fixes

BREAKING CHANGE: The host list border rendering has been refactored to use manual ASCII box drawing, which may affect custom styling or layout expectations.