### PR TITLE
fix(ftp): stop site list panic when switching narrow/wide layouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.1] - 2026-09-12
+
+### Fixed
+
+- **FTP site list panic on narrow terminals** — Switching between 3-column (narrow) and 4-column (wide) layouts on a populated table panicked (`index out of range`) because bubbles `renderRow` indexes columns by row length. Rows are now drained before the column swap. Affected e.g. phones in portrait (`ctty ftp` crashed on launch).
+
 ## [0.7.0] - 2026-09-12
 
 ### Added

--- a/internal/ui/ftp_manage_test.go
+++ b/internal/ui/ftp_manage_test.go
@@ -548,3 +548,29 @@ func TestColorizeSiteTagsLongestFirst(t *testing.T) {
 		t.Fatalf("overlapping tags corrupted: %q", got)
 	}
 }
+
+func TestFTPSitesNarrowWideSwitchNoPanic(t *testing.T) {
+	i18n.SetLang("en")
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("HOME", dir)
+
+	m := NewFTPSitesForm(NewStyles(100), 100, 30)
+	m.sites = []ftpconfig.FTPSite{
+		{Name: "lab", Host: "10.0.0.1", Port: 21, User: "admin", Tags: []string{"ops"}},
+	}
+	m.applyFilter()
+	m.rebuildTable()
+
+	for _, w := range []int{60, 100, 60, 140, 40} {
+		updated, _ := m.Update(tea.WindowSizeMsg{Width: w, Height: 30})
+		m = updated.(*ftpSitesModel)
+		if w < 74 && len(m.table.Columns()) != 3 {
+			t.Fatalf("width %d: want 3 columns, got %d", w, len(m.table.Columns()))
+		}
+		if w >= 74 && len(m.table.Columns()) != 4 {
+			t.Fatalf("width %d: want 4 columns, got %d", w, len(m.table.Columns()))
+		}
+		_ = m.View()
+	}
+}

--- a/internal/ui/ftp_sites.go
+++ b/internal/ui/ftp_sites.go
@@ -258,6 +258,11 @@ func (m *ftpSitesModel) rebuildTable() {
 		if m.table.Columns() == nil || len(m.table.Columns()) == 0 {
 			m.table = table.New(table.WithColumns(cols), table.WithHeight(h), table.WithFocused(true))
 		} else {
+			// Drain rows first: bubbles renderRow indexes columns by row
+			// length, so swapping 3/4-column layouts on a populated
+			// table panics. SetRows(nil) renders nothing, making the
+			// column swap safe in both directions.
+			m.table.SetRows(nil)
 			m.table.SetColumns(cols)
 			m.table.SetHeight(h)
 		}
@@ -296,6 +301,7 @@ func (m *ftpSitesModel) rebuildTable() {
 	if m.table.Columns() == nil || len(m.table.Columns()) == 0 {
 		m.table = table.New(table.WithColumns(cols), table.WithHeight(h), table.WithFocused(true))
 	} else {
+		m.table.SetRows(nil)
 		m.table.SetColumns(cols)
 		m.table.SetHeight(h)
 	}


### PR DESCRIPTION
Drain table rows before swapping 3/4-column layouts: bubbles renderRow indexes columns by row length, so resizing across the 74-column threshold on a populated table panicked with index out of range. Crashed 'ctty ftp' on narrow terminals (e.g. phones).