### PR TITLE
fix(android): add Android (Termux) support to installation scripts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,16 @@ jobs:
           go-version: '1.23'
           cache: true
 
+      # NDK provides the clang toolchain for the cgo Android builds
+      # (bionic DNS resolver). Pinned so the toolchain path is stable.
+      - name: Set up Android NDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install pinned NDK and add toolchain to PATH
+        run: |
+          sdkmanager "ndk;27.1.12297006"
+          echo "${ANDROID_SDK_ROOT:-$ANDROID_HOME}/ndk/27.1.12297006/toolchains/llvm/prebuilt/linux-x86_64/bin" >> $GITHUB_PATH
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,6 +36,43 @@ builds:
   flags:
   - -trimpath
 
+# Android builds use cgo so DNS goes through bionic (pure-Go resolver
+# breaks on devices with Private DNS / stub resolvers). NDK toolchain
+# must be on PATH (see release workflow); one entry per arch because
+# each needs its own CC.
+- id: ctty-android-arm64
+  main: ./main.go
+  binary: ctty
+  goos:
+  - android
+  goarch:
+  - arm64
+  env:
+  - CGO_ENABLED=1
+  - CC=aarch64-linux-android24-clang
+  ldflags:
+  - -s -w
+  - -X github.com/zsuroy/ctty/cmd.AppVersion={{.Version}}
+  flags:
+  - -trimpath
+- id: ctty-android-arm
+  main: ./main.go
+  binary: ctty
+  goos:
+  - android
+  goarch:
+  - arm
+  goarm:
+  - "7"
+  env:
+  - CGO_ENABLED=1
+  - CC=armv7a-linux-androideabi24-clang
+  ldflags:
+  - -s -w
+  - -X github.com/zsuroy/ctty/cmd.AppVersion={{.Version}}
+  flags:
+  - -trimpath
+
 archives:
 - id: ctty
   formats: [ "tar.gz" ]
@@ -77,6 +114,8 @@ changelog:
 # Homebrew tap configuration (Formula pour CLI)
 brews:
 - name: ctty
+  ids:
+  - ctty
   repository:
     owner: zsuroy
     name: homebrew-ctty

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.7.2] - 2026-09-12
+
+### Added
+
+- **Android (Termux) release builds** — cgo `ctty_Android_arm64`/`ctty_Android_armv7` artifacts (NDK, API 24+): DNS goes through the bionic resolver, fixing `connection refused` on devices where the pure-Go resolver picks a dead stub (e.g. `[::1]:53`). The installer picks the Android asset on Termux with Linux fallback; the password vault is shared with the Linux build.
+
 ## [0.7.1] - 2026-09-12
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,13 @@ build:
 build-local: VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 build-local: build
 
+# Android (Termux) build with cgo so DNS goes through bionic.
+# Requires NDK clang as CC, e.g.:
+#   CC=$ANDROID_NDK_HOME/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android28-clang make build-android
+build-android:
+	@mkdir -p dist
+	CGO_ENABLED=1 GOOS=android GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o dist/ctty-android-arm64 .
+
 # Run tests
 test:
 	go test ./...

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ curl -sSL https://raw.githubusercontent.com/zsuroy/ctty/master/install/unix.sh |
 ```bash
 curl -sSL https://raw.githubusercontent.com/zsuroy/ctty/master/install/unix.sh | bash
 ```
-The installer auto-detects Termux (via `$PREFIX`/`$TERMUX_VERSION`) and installs to `$PREFIX/bin` without `sudo`.
+The installer auto-detects Termux (via `$PREFIX`/`$TERMUX_VERSION`) and installs to `$PREFIX/bin` without `sudo`. On Termux it picks the cgo Android build, whose DNS goes through the system resolver (pure-Go builds fail on devices with Private DNS or stub resolvers); releases without Android assets fall back to the Linux build.
 
 **Windows (PowerShell):**
 ```powershell
@@ -866,7 +866,7 @@ ctty remembers your port forwarding configurations for easy reuse:
 - Detected automatically by the `install/unix.sh` installer
 - Installs to `$PREFIX/bin` (e.g. `~/termux/files/usr/bin`), not `/usr/local/bin`
 - No `sudo` — runs with the Termux user permissions
-- Architecture detection (`aarch64 → arm64`, `armv7* → armv7`) works unchanged, so the standard release artifacts install correctly
+- Architecture detection (`aarch64 → arm64`, `armv7* → armv7`) picks the cgo `ctty_Android_*` release asset, which uses Android system DNS (the pure-Go resolver breaks on some devices, e.g. `[::1]:53 connection refused`); the saved-password vault is shared with the Linux build
 
 ## 🏗️ Configuration
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -104,7 +104,7 @@ curl -sSL https://raw.githubusercontent.com/zsuroy/ctty/master/install/unix.sh |
 ```bash
 curl -sSL https://raw.githubusercontent.com/zsuroy/ctty/master/install/unix.sh | bash
 ```
-安装器自动检测 Termux（通过 `$PREFIX`/`$TERMUX_VERSION`），安装到 `$PREFIX/bin` 且不使用 `sudo`。
+安装器自动检测 Termux（通过 `$PREFIX`/`$TERMUX_VERSION`），安装到 `$PREFIX/bin` 且不使用 `sudo`。在 Termux 上会自动选择 cgo 编译的 Android 包，其 DNS 走系统解析（纯 Go 包在 Private DNS 或 stub 解析的机器上会失败）；没有 Android 产物的老版本回退到 Linux 包。
 
 **Windows（PowerShell）：**
 ```powershell
@@ -860,7 +860,7 @@ ctty 记住你的端口转发配置以便快速复用：
 - 由 `install/unix.sh` 安装器自动检测
 - 安装到 `$PREFIX/bin`（如 `~/termux/files/usr/bin`），而非 `/usr/local/bin`
 - 无需 `sudo`，以 Termux 用户权限运行
-- 架构检测（`aarch64 → arm64`、`armv7* → armv7`）保持不变，标准发布产物可直接安装
+- 架构检测（`aarch64 → arm64`、`armv7* → armv7`）选择 cgo 编译的 `ctty_Android_*` 发布包，走 Android 系统 DNS（纯 Go 解析在部分机器上会挂，如 `[::1]:53 connection refused`）；已存密码保险库与 Linux 包共用
 
 ## 🏗️ 配置
 

--- a/install/README.md
+++ b/install/README.md
@@ -2,7 +2,7 @@
 
 This directory contains installation scripts for ctty.
 
-## Unix/Linux/macOS Installation
+## Unix/Linux/macOS/Android (Via Termux) Installation
 
 ### Quick Install (Recommended)
 
@@ -32,7 +32,7 @@ iex "& { $(irm https://raw.githubusercontent.com/zsuroy/ctty/master/install/wind
 iex "& { $(irm https://raw.githubusercontent.com/zsuroy/ctty/master/install/windows.ps1) } -InstallDir 'C:\tools'"
 ```
 
-## Unix/Linux/macOS Advanced Options
+## Unix/Linux/macOS/Android Advanced Options
 
 **Force install without prompts:**
 ```bash
@@ -73,6 +73,7 @@ chmod +x unix.sh
 
 - **Linux**: AMD64, ARM64
 - **macOS**: AMD64 (Intel), ARM64 (Apple Silicon)
+- **Android (Termux)**: ARM64, ARMv7 (cgo build with working Android DNS; falls back to the Linux binary on releases without Android assets)
 
 ## Requirements
 

--- a/install/unix.sh
+++ b/install/unix.sh
@@ -147,15 +147,22 @@ getLatestVersion() {
 }
 
 downloadBinary() {
-    # Map OS names to match GoReleaser format
+    # Map OS names to match GoReleaser format.
+    # Termux takes the cgo Android build (bionic DNS resolver); older
+    # releases without Android assets fall back to the Linux build.
     local GORELEASER_OS="$OS"
     case $OS in
         "darwin") GORELEASER_OS="Darwin" ;;
-        "linux") GORELEASER_OS="Linux" ;;
+        "linux")
+            if [ "$IS_TERMUX" = "true" ]; then
+                GORELEASER_OS="Android"
+            else
+                GORELEASER_OS="Linux"
+            fi ;;
         "windows") GORELEASER_OS="Windows" ;;
     esac
-    
-    # Map architecture names to match GoReleaser format  
+
+    # Map architecture names to match GoReleaser format
     local GORELEASER_ARCH="$ARCH"
     case $ARCH in
         "amd64") GORELEASER_ARCH="x86_64" ;;
@@ -164,42 +171,54 @@ downloadBinary() {
         "armv6") GORELEASER_ARCH="armv6" ;;
         "armv7") GORELEASER_ARCH="armv7" ;;
     esac
-    
-    # GoReleaser format: ctty_Linux_armv7.tar.gz
-    GITHUB_FILE="ctty_${GORELEASER_OS}_${GORELEASER_ARCH}.tar.gz"
-    GITHUB_URL="https://github.com/zsuroy/ctty/releases/download/$LATEST_VERSION/$GITHUB_FILE"
-    CHECKSUMS_URL="https://github.com/zsuroy/ctty/releases/download/$LATEST_VERSION/checksums.txt"
-    ARCHIVE_PATH="$TEMP_DIR/$GITHUB_FILE"
-    CHECKSUMS_PATH="$TEMP_DIR/checksums.txt"
-    
-    printf "${YELLOW}Downloading $GITHUB_FILE...${NC}\n"
-    if ! curl --fail --location --proto '=https' --tlsv1.2 "$GITHUB_URL" --progress-bar --output "$ARCHIVE_PATH"; then
-        printf "${RED}Failed to download binary${NC}\n"
-        exit 1
+
+    local OS_CANDIDATES="$GORELEASER_OS"
+    if [ "$GORELEASER_OS" = "Android" ]; then
+        OS_CANDIDATES="Android Linux"
     fi
+
+    CHECKSUMS_URL="https://github.com/zsuroy/ctty/releases/download/$LATEST_VERSION/checksums.txt"
+    CHECKSUMS_PATH="$TEMP_DIR/checksums.txt"
 
     printf "${YELLOW}Downloading release checksums...${NC}\n"
     if ! curl --fail --location --proto '=https' --tlsv1.2 "$CHECKSUMS_URL" --silent --show-error --output "$CHECKSUMS_PATH"; then
         printf "${RED}Failed to download release checksums${NC}\n"
         exit 1
     fi
-    if ! verifyChecksum "$ARCHIVE_PATH" "$CHECKSUMS_PATH" "$GITHUB_FILE"; then
-        exit 1
-    fi
-    
-    # Extract the binary
-    if ! tar -xzf "$ARCHIVE_PATH" -C "$TEMP_DIR"; then
-        printf "${RED}Failed to extract binary${NC}\n"
-        exit 1
-    fi
-    
-    # GoReleaser extracts the binary as just "ctty", not with the platform suffix
-    EXTRACTED_BINARY="$TEMP_DIR/ctty"
-    if [ ! -f "$EXTRACTED_BINARY" ]; then
-        printf "${RED}Could not find extracted binary: $EXTRACTED_BINARY${NC}\n"
-        exit 1
-    fi
-    DOWNLOADED_BINARY="$EXTRACTED_BINARY"
+
+    for candidate in $OS_CANDIDATES; do
+        # GoReleaser format: ctty_Linux_armv7.tar.gz
+        GITHUB_FILE="ctty_${candidate}_${GORELEASER_ARCH}.tar.gz"
+        GITHUB_URL="https://github.com/zsuroy/ctty/releases/download/$LATEST_VERSION/$GITHUB_FILE"
+        ARCHIVE_PATH="$TEMP_DIR/$GITHUB_FILE"
+
+        printf "${YELLOW}Downloading $GITHUB_FILE...${NC}\n"
+        if ! curl --fail --location --proto '=https' --tlsv1.2 "$GITHUB_URL" --progress-bar --output "$ARCHIVE_PATH"; then
+            printf "${YELLOW}Asset $GITHUB_FILE not found, trying next...${NC}\n"
+            continue
+        fi
+        if ! verifyChecksum "$ARCHIVE_PATH" "$CHECKSUMS_PATH" "$GITHUB_FILE"; then
+            exit 1
+        fi
+
+        # Extract the binary
+        if ! tar -xzf "$ARCHIVE_PATH" -C "$TEMP_DIR"; then
+            printf "${RED}Failed to extract binary${NC}\n"
+            exit 1
+        fi
+
+        # GoReleaser extracts the binary as just "ctty", not with the platform suffix
+        EXTRACTED_BINARY="$TEMP_DIR/ctty"
+        if [ ! -f "$EXTRACTED_BINARY" ]; then
+            printf "${RED}Could not find extracted binary: $EXTRACTED_BINARY${NC}\n"
+            exit 1
+        fi
+        DOWNLOADED_BINARY="$EXTRACTED_BINARY"
+        return 0
+    done
+
+    printf "${RED}Failed to download binary${NC}\n"
+    exit 1
 }
 
 install() {

--- a/internal/credential/credential.go
+++ b/internal/credential/credential.go
@@ -76,11 +76,22 @@ func deriveMachineKey() []byte {
 		user = os.Getenv("USERNAME")
 	}
 	hostname, _ := os.Hostname()
-	goos := runtime.GOOS
+	goos := normalizeVaultGOOS(runtime.GOOS)
 
 	seed := "ctty-secret-key-" + user + "@" + hostname + "-" + goos
 	hash := sha256.Sum256([]byte(seed))
 	return hash[:]
+}
+
+// normalizeVaultGOOS maps platform names for vault key derivation.
+// Android shares the Linux vault so Termux users can switch between
+// the linux and android builds on one device without re-entering
+// saved passwords. All other platforms keep their own key.
+func normalizeVaultGOOS(goos string) string {
+	if goos == "android" {
+		return "linux"
+	}
+	return goos
 }
 
 // encrypt encrypts plaintext using AES-256-GCM.

--- a/internal/credential/credential_test.go
+++ b/internal/credential/credential_test.go
@@ -156,3 +156,14 @@ func TestCredentialStoreFailsClosedAndRetriesAfterRepair(t *testing.T) {
 		t.Fatalf("GetPassword = %q, %v; want repaired credential", password, ok)
 	}
 }
+
+func TestNormalizeVaultGOOS(t *testing.T) {
+	if got := normalizeVaultGOOS("android"); got != "linux" {
+		t.Fatalf("normalizeVaultGOOS(android) = %q, want linux", got)
+	}
+	for _, p := range []string{"linux", "darwin", "windows", ""} {
+		if got := normalizeVaultGOOS(p); got != p {
+			t.Fatalf("normalizeVaultGOOS(%q) = %q, want unchanged", p, got)
+		}
+	}
+}


### PR DESCRIPTION
Add Android (Termux) support to installation scripts:
1. Update release.yml to install Android NDK for cgo builds
2. Add Android build target to Makefile
3. Update README.md to include Android (Termux) installation instructions
4. Modify unix.sh to handle Termux-specific downloads and fallbacks

The changes maintain existing installation structure while adding Android support.