### PR TITLE
fix(android): resolve self-update binary path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - **Standalone local file browser (`ctty browse [path]`)** — Single-pane local filesystem manager: navigate, search, mkdir/delete with confirm (recursive)/rename, file details, open-with-default-app; bilingual help.
 
+### Fixed
+
+- **Self-update on Android (`ExecPath not implemented for android`)** — minio's internal executable lookup doesn't handle GOOS=android, so `ctty update` failed on Termux. ctty now resolves its own binary path (`os.Executable` with PATH fallback) and passes it explicitly.
+
 ## [0.7.3] - 2026-09-12
 
 ### Added

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -16,6 +16,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -199,6 +201,21 @@ func humanBytes(n int64) string {
 	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
 }
 
+// currentExecutablePath resolves the running binary without minio's
+// internal osext lookup, which errors with "ExecPath not implemented
+// for android". Falls back to PATH lookup when os.Executable fails.
+func currentExecutablePath() (string, error) {
+	if exe, err := os.Executable(); err == nil && exe != "" {
+		return exe, nil
+	}
+	if len(os.Args) > 0 {
+		if abs, err := exec.LookPath(os.Args[0]); err == nil {
+			return abs, nil
+		}
+	}
+	return "", fmt.Errorf("cannot locate running binary (os.Executable failed)")
+}
+
 // Apply downloads the latest release archive, verifies its sha256 against the
 // published checksums.txt, extracts the binary, and atomically replaces the
 // running executable. The process must be restarted afterwards to run the new
@@ -254,7 +271,11 @@ func Apply(ctx context.Context, cb Progress) error {
 	}
 
 	cb("applying", "Replacing binary ...")
-	if err := selfupdate.Apply(bytes.NewReader(bin), selfupdate.Options{}); err != nil {
+	target, err := currentExecutablePath()
+	if err != nil {
+		return fmt.Errorf("apply update: %s", err)
+	}
+	if err := selfupdate.Apply(bytes.NewReader(bin), selfupdate.Options{TargetPath: target}); err != nil {
 		msg := err.Error()
 		if strings.Contains(msg, "permission denied") || strings.Contains(msg, "access is denied") {
 			msg += " (hint: insufficient permissions to replace the binary)"

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -158,3 +158,13 @@ func TestExtractBinaryMissingEntry(t *testing.T) {
 		t.Fatal("expected error when binary entry absent")
 	}
 }
+
+func TestCurrentExecutablePath(t *testing.T) {
+	p, err := currentExecutablePath()
+	if err != nil {
+		t.Fatalf("currentExecutablePath: %v", err)
+	}
+	if p == "" {
+		t.Fatal("expected non-empty executable path")
+	}
+}

--- a/internal/ui/update_form.go
+++ b/internal/ui/update_form.go
@@ -228,14 +228,16 @@ func (m *updateFormModel) View() string {
 		body = m.renderConfirm()
 	case updateRunning:
 		spinner := updateSpinnerFrames[m.frame]
-		bar := progressBar(m.percent, 32)
+		bar := progressBar(m.percent, max(10, min(32, m.width-13)))
+		progressLine := ansi.Truncate(spinner+" "+m.progress, max(10, m.width-8), "…")
+		hint := ansi.Wrap(i18n.T("update.running_hint"), max(10, m.width-8), " ")
 		body = lipgloss.JoinVertical(lipgloss.Center,
 			m.styles.FormTitle.Render(i18n.T("update.modal_title")),
 			"",
-			spinner+" "+m.progress,
+			progressLine,
 			bar,
 			"",
-			m.styles.HelpText.Faint(true).Render(i18n.T("update.running_hint")),
+			m.styles.HelpText.Faint(true).Render(hint),
 		)
 	case updateDone:
 		body = lipgloss.JoinVertical(lipgloss.Center,

--- a/internal/ui/update_form_test.go
+++ b/internal/ui/update_form_test.go
@@ -60,3 +60,18 @@ func TestHelpFormShowsRepoURL(t *testing.T) {
 		t.Errorf("help form missing repo URL %q:\n%s", version.RepoURL(), view)
 	}
 }
+
+func TestUpdateRunningProgressTruncatesToWidth(t *testing.T) {
+	i18n.SetLang("en")
+	for _, w := range []int{30, 40, 60, 100} {
+		form := NewUpdateForm(NewStyles(w), w, 24, "v0.6.0", "v0.7.0", "https://example.com")
+		form.phase = updateRunning
+		form.percent = 8
+		form.progress = "Downloading ctty_Android_arm64.tar.gz ... 1.2 MB / 14.5 MB (8%)"
+		for _, line := range strings.Split(form.View(), "\n") {
+			if got := lineDisplayWidth(line); got > w {
+				t.Fatalf("width=%d: line %d cols exceeds terminal: %q", w, got, line)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fix self-update on Android by implementing a robust binary path resolution method that handles GOOS=android. The new method uses os.Executable with a PATH fallback, ensuring compatibility across different platforms. Update the progress bar and hint text in the update form to dynamically adjust to terminal width, improving user experience. Add tests for the new binary path resolution method and ensure the update form view respects terminal width constraints.

BREAKING CHANGE: The self-update functionality now requires explicit binary path resolution, which may affect existing implementations that rely on minio's internal osext lookup.